### PR TITLE
Deny `warnings` and `missing-docs` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
+    env:
+      RUSTFLAGS: -D warnings -D missing-docs
     strategy:
       matrix:
         rust: [stable, beta]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! TODO
+
 #[cfg(test)]
 mod test {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(missing_docs)]
+
 //! TODO
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(missing_docs)]
+
 //! TODO
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! TODO
+
 fn main() {
     println!("Hello world from Chronicle!");
 }


### PR DESCRIPTION
I think we should deny warnings and documentation in CI. In general, I think these are good defaults, and it is more convenient for development to do that in CI, rather than adding `#[deny(...)]` to the crates. What do you think?