### PR TITLE
Add type to `ActorError`

### DIFF
--- a/bin/inx-chronicle/src/main.rs
+++ b/bin/inx-chronicle/src/main.rs
@@ -8,7 +8,7 @@ mod cli;
 mod config;
 mod listener;
 
-use std::error::Error;
+use std::{error::Error, ops::Deref};
 
 use async_trait::async_trait;
 use broker::{Broker, BrokerError};
@@ -88,7 +88,7 @@ impl HandleEvent<Report<Broker>> for Launcher {
                 cx.shutdown();
             }
             Err(e) => match e.error {
-                ActorError::Result(e) => match e.downcast_ref::<BrokerError>().unwrap() {
+                ActorError::Result(e) => match e.deref() {
                     BrokerError::RuntimeError(_) => {
                         cx.shutdown();
                     }
@@ -128,7 +128,7 @@ impl HandleEvent<Report<InxListener>> for Launcher {
                 cx.shutdown();
             }
             Err(e) => match &e.error {
-                ActorError::Result(e) => match e.downcast_ref::<InxListenerError>().unwrap() {
+                ActorError::Result(e) => match e.deref() {
                     InxListenerError::Inx(e) => match e {
                         InxError::TransportFailed => {
                             cx.spawn_actor_supervised(InxListener::new(config.inx.clone(), broker_addr.clone()))

--- a/src/runtime/actor/error.rs
+++ b/src/runtime/actor/error.rs
@@ -1,15 +1,17 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{error::Error, sync::Arc};
+use std::sync::Arc;
 
 use thiserror::Error;
 
+use super::Actor;
+
 #[allow(missing_docs)]
 #[derive(Error, Debug)]
-pub enum ActorError {
+pub enum ActorError<A: Actor> {
     #[error("Actor error: {0:?}")]
-    Result(Arc<Box<dyn Error + Send + Sync>>),
+    Result(Arc<A::Error>),
     #[error("Actor panicked")]
     Panic,
     #[error("Actor aborted")]

--- a/src/runtime/actor/report.rs
+++ b/src/runtime/actor/report.rs
@@ -29,11 +29,11 @@ pub struct ErrorReport<A: Actor> {
     /// The actor's internal state when it finished running
     pub internal_state: Option<A::State>,
     /// The error that occurred
-    pub error: ActorError,
+    pub error: ActorError<A>,
 }
 
 impl<A: Actor> ErrorReport<A> {
-    pub(crate) fn new(actor: A, internal_state: Option<A::State>, error: ActorError) -> Report<A> {
+    pub(crate) fn new(actor: A, internal_state: Option<A::State>, error: ActorError<A>) -> Report<A> {
         Err(Self {
             actor,
             internal_state,

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -23,7 +23,9 @@ pub enum RuntimeError {
     #[error("Duplicate actor {0} in scope {1:x}")]
     DuplicateActor(String, ScopeId),
     #[error("Actor exited with error: {0}")]
-    ActorError(Arc<Box<dyn Error + Send + Sync>>),
+    ActorError(Arc<dyn Error + Send + Sync>),
+    #[error("Task exited with error: {0}")]
+    TaskError(Box<dyn Error + Send + Sync>),
     #[error(transparent)]
     SendError(#[from] SendError),
 }

--- a/src/runtime/scope.rs
+++ b/src/runtime/scope.rs
@@ -168,7 +168,7 @@ impl RuntimeScope {
                                 format!("Task {:x}", child_scope.id().as_fields().0),
                                 e
                             );
-                            Err(RuntimeError::ActorError(Arc::new(e)))
+                            Err(RuntimeError::TaskError(e))
                         }
                     },
                     Err(e) => {
@@ -229,7 +229,7 @@ impl RuntimeScope {
                         }
                         Err(e) => {
                             log::error!("{} exited with error: {}", actor.name(), e);
-                            let e = Arc::new(Box::new(e) as Box<dyn Error + Send + Sync>);
+                            let e = Arc::new(e);
                             supervisor_addr.send(ErrorReport::new(actor, data, ActorError::Result(e.clone())))?;
                             Err(RuntimeError::ActorError(e))
                         }
@@ -266,9 +266,7 @@ impl RuntimeScope {
                         Ok(_) => Ok(()),
                         Err(e) => {
                             log::error!("{} exited with error: {}", actor.name(), e);
-                            Err(RuntimeError::ActorError(Arc::new(
-                                Box::new(e) as Box<dyn Error + Send + Sync>
-                            )))
+                            Err(RuntimeError::ActorError(Arc::new(e)))
                         }
                     },
                     Err(e) => {


### PR DESCRIPTION
Adds the actor type to the error enum so that no weird downcasting is needed in supervisor error handling.