### PR TITLE
Add panic hook

### DIFF
--- a/bin/inx-chronicle/src/main.rs
+++ b/bin/inx-chronicle/src/main.rs
@@ -222,6 +222,10 @@ async fn main() {
     dotenv::dotenv().ok();
     env_logger::init();
 
+    std::panic::set_hook(Box::new(|p| {
+        log::error!("{}", p);
+    }));
+
     if let Err(e) = Runtime::launch(startup).await {
         log::error!("{}", e);
     }


### PR DESCRIPTION
Add a panic hook to print panics in a way that doesn't disrupt our logging.

## Before
```
[2022-04-22T11:53:37Z DEBUG inx_chronicle::api] inx_chronicle::api::ApiWorker shutting down (376e36fd-68b7-460f-8a1d-239832f157f4)
thread '[2022-04-22T11:53:37Z DEBUG chronicle::runtime::actor] inx_chronicle::broker::Broker exited event loop (adc3cac4-845b-4000-8cae-cd6b52eb8795)
tokio-runtime-worker[2022-04-22T11:53:37Z DEBUG h2::codec::framed_write] send frame=GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }
[2022-04-22T11:53:38Z DEBUG chronicle::runtime::actor] inx_chronicle::broker::Broker shutting down (adc3cac4-845b-4000-8cae-cd6b52eb8795)
[2022-04-22T11:53:38Z DEBUG chronicle::runtime::scope] Joining scope adc3cac4
[2022-04-22T11:53:38Z DEBUG h2::proto::connection] Connection::poll; connection error error=GoAway(b"", NO_ERROR, Library)
' panicked at 'called `Result::unwrap()` on an `Err` value: JoinError::Panic(...)', bin/inx-chronicle/src\api\mod.rs:80:31
[2022-04-22T11:53:38Z DEBUG chronicle::runtime::scope] Joining scope 376e36fd
```

## After
```
[2022-04-22T12:22:36Z DEBUG inx_chronicle::api] inx_chronicle::api::ApiWorker shutting down (33356102-38a5-4688-9054-0bb321ccd288)
[2022-04-22T12:22:36Z ERROR inx_chronicle] panicked at 'called `Result::unwrap()` on an `Err` value: JoinError::Panic(...)', bin/inx-chronicle/src\api\mod.rs:80:31     
[2022-04-22T12:22:36Z DEBUG chronicle::runtime::scope] Joining scope 33356102
```