### PR TITLE
Add Address Registry to the runtime

### DIFF
--- a/bin/inx-chronicle/src/inx/listener.rs
+++ b/bin/inx-chronicle/src/inx/listener.rs
@@ -8,7 +8,7 @@ use std::{fmt::Debug, marker::PhantomData};
 
 use async_trait::async_trait;
 use chronicle::runtime::{
-    actor::{addr::Addr, context::ActorContext, error::ActorError, event::HandleEvent, report::Report, Actor},
+    actor::{context::ActorContext, error::ActorError, event::HandleEvent, report::Report, Actor},
     config::ConfigureActor,
 };
 use inx::{
@@ -36,16 +36,12 @@ pub enum InxListenerError {
 #[derive(Debug)]
 pub struct InxListener {
     inx: InxClient<Channel>,
-    broker_addr: Addr<Broker>,
 }
 
 impl InxListener {
     // TODO: Should we check for broker actor here too?
-    pub fn new(client: InxClient<Channel>, broker_addr: Addr<Broker>) -> Self {
-        Self {
-            inx: client,
-            broker_addr,
-        }
+    pub fn new(client: InxClient<Channel>) -> Self {
+        Self { inx: client }
     }
 }
 
@@ -57,16 +53,12 @@ impl Actor for InxListener {
     async fn init(&mut self, cx: &mut ActorContext<Self>) -> Result<Self::State, Self::Error> {
         let message_stream = self.inx.listen_to_messages(MessageFilter {}).await?.into_inner();
 
-        cx.spawn_actor_supervised::<MessageStream, _>(
-            InxStreamListener::new(self.broker_addr.clone())?.with_stream(message_stream),
-        )
-        .await;
+        cx.spawn_child::<MessageStream, _>(InxStreamListener::default().with_stream(message_stream))
+            .await;
 
         let milestone_stream = self.inx.listen_to_latest_milestone(NoParams {}).await?.into_inner();
-        cx.spawn_actor_supervised::<MilestoneStream, _>(
-            InxStreamListener::new(self.broker_addr.clone())?.with_stream(milestone_stream),
-        )
-        .await;
+        cx.spawn_child::<MilestoneStream, _>(InxStreamListener::default().with_stream(milestone_stream))
+            .await;
 
         Ok(())
     }
@@ -81,16 +73,14 @@ impl HandleEvent<Report<MessageStream>> for InxListener {
         _: &mut Self::State,
     ) -> Result<(), Self::Error> {
         match event {
-            Ok(_) => {
+            Report::Success(_) => {
                 cx.shutdown();
             }
-            Err(e) => match e.error {
+            Report::Error(report) => match report.error {
                 ActorError::Result(_) => {
                     let message_stream = self.inx.listen_to_messages(MessageFilter {}).await?.into_inner();
-                    cx.spawn_actor_supervised::<MessageStream, _>(
-                        InxStreamListener::new(self.broker_addr.clone())?.with_stream(message_stream),
-                    )
-                    .await;
+                    cx.spawn_child::<MessageStream, _>(InxStreamListener::default().with_stream(message_stream))
+                        .await;
                 }
                 ActorError::Aborted | ActorError::Panic => {
                     cx.shutdown();
@@ -110,16 +100,14 @@ impl HandleEvent<Report<MilestoneStream>> for InxListener {
         _: &mut Self::State,
     ) -> Result<(), Self::Error> {
         match event {
-            Ok(_) => {
+            Report::Success(_) => {
                 cx.shutdown();
             }
-            Err(e) => match e.error {
+            Report::Error(report) => match report.error {
                 ActorError::Result(_) => {
                     let milestone_stream = self.inx.listen_to_latest_milestone(NoParams {}).await?.into_inner();
-                    cx.spawn_actor_supervised::<MilestoneStream, _>(
-                        InxStreamListener::new(self.broker_addr.clone())?.with_stream(milestone_stream),
-                    )
-                    .await;
+                    cx.spawn_child::<MilestoneStream, _>(InxStreamListener::default().with_stream(milestone_stream))
+                        .await;
                 }
                 ActorError::Aborted | ActorError::Panic => {
                     cx.shutdown();
@@ -131,19 +119,13 @@ impl HandleEvent<Report<MilestoneStream>> for InxListener {
 }
 
 pub struct InxStreamListener<I> {
-    broker_addr: Addr<Broker>,
     _item: PhantomData<I>,
 }
 
-impl<I> InxStreamListener<I> {
-    pub fn new(broker_addr: Addr<Broker>) -> Result<Self, InxListenerError> {
-        if broker_addr.is_closed() {
-            Err(InxListenerError::MissingBroker)
-        } else {
-            Ok(Self {
-                broker_addr,
-                _item: PhantomData,
-            })
+impl<I> Default for InxStreamListener<I> {
+    fn default() -> Self {
+        Self {
+            _item: Default::default(),
         }
     }
 }
@@ -171,11 +153,11 @@ where
 {
     async fn handle_event(
         &mut self,
-        _cx: &mut ActorContext<Self>,
+        cx: &mut ActorContext<Self>,
         event: Result<E, Status>,
         _state: &mut Self::State,
     ) -> Result<(), Self::Error> {
-        self.broker_addr.send(event?)?;
+        cx.addr::<Broker>().await.send(event?)?;
         Ok(())
     }
 }

--- a/bin/inx-chronicle/src/inx/listener.rs
+++ b/bin/inx-chronicle/src/inx/listener.rs
@@ -119,7 +119,8 @@ impl HandleEvent<Report<MilestoneStream>> for InxListener {
 }
 
 pub struct InxStreamListener<I> {
-    _item: PhantomData<I>,
+    // This funky phantom fn pointer is so that the type impls Send + Sync
+    _item: PhantomData<fn(I) -> I>,
 }
 
 impl<I> Default for InxStreamListener<I> {
@@ -134,7 +135,7 @@ impl<I> Default for InxStreamListener<I> {
 impl<E> Actor for InxStreamListener<E>
 where
     Broker: HandleEvent<E>,
-    E: 'static + Send + Sync + Debug,
+    E: 'static + Send,
 {
     type State = ();
     type Error = InxListenerError;
@@ -149,7 +150,7 @@ impl<E> HandleEvent<Result<E, Status>> for InxStreamListener<E>
 where
     Self: Actor<Error = InxListenerError>,
     Broker: HandleEvent<E>,
-    E: 'static + Send + Sync + Debug,
+    E: 'static + Send,
 {
     async fn handle_event(
         &mut self,

--- a/src/runtime/actor/addr.rs
+++ b/src/runtime/actor/addr.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
+
 use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -77,5 +79,37 @@ impl<A: Actor> Clone for Addr<A> {
             scope: self.scope.clone(),
             sender: self.sender.clone(),
         }
+    }
+}
+
+/// An optional address, which allows sending events.
+#[derive(Debug, Clone)]
+pub struct OptionalAddr<A: Actor>(Option<Addr<A>>);
+
+impl<A: Actor> OptionalAddr<A> {
+    /// Sends an event if the address exists. Returns an error if the address is not set.
+    pub fn send<E>(&self, event: E) -> Result<(), RuntimeError>
+    where
+        A: Actor + Send + Sync + 'static,
+        E: 'static + DynEvent<A> + Send + Sync,
+    {
+        self.0
+            .as_ref()
+            .ok_or_else(|| SendError::new(format!("No open address for {}", std::any::type_name::<A>())))?
+            .send(event)
+    }
+}
+
+impl<A: Actor> From<Option<Addr<A>>> for OptionalAddr<A> {
+    fn from(opt_addr: Option<Addr<A>>) -> Self {
+        Self(opt_addr)
+    }
+}
+
+impl<A: Actor> Deref for OptionalAddr<A> {
+    type Target = Option<Addr<A>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/runtime/actor/addr.rs
+++ b/src/runtime/actor/addr.rs
@@ -58,7 +58,7 @@ impl<A: Actor> Addr<A> {
     }
 
     /// Sends a message to the actor
-    pub fn send<E: 'static + DynEvent<A> + Send + Sync>(&self, event: E) -> Result<(), RuntimeError>
+    pub fn send<E: 'static + DynEvent<A>>(&self, event: E) -> Result<(), RuntimeError>
     where
         Self: Sized,
     {
@@ -90,8 +90,8 @@ impl<A: Actor> OptionalAddr<A> {
     /// Sends an event if the address exists. Returns an error if the address is not set.
     pub fn send<E>(&self, event: E) -> Result<(), RuntimeError>
     where
-        A: Actor + Send + Sync + 'static,
-        E: 'static + DynEvent<A> + Send + Sync,
+        A: 'static + Actor,
+        E: 'static + DynEvent<A>,
     {
         self.0
             .as_ref()

--- a/src/runtime/actor/context.rs
+++ b/src/runtime/actor/context.rs
@@ -42,14 +42,14 @@ impl<A: Actor> ActorContext<A> {
     }
 
     /// Spawn a new supervised child actor.
-    pub async fn spawn_actor_supervised<OtherA, Cfg>(&mut self, actor: Cfg) -> Addr<OtherA>
+    pub async fn spawn_child<OtherA, Cfg>(&mut self, actor: Cfg) -> Addr<OtherA>
     where
         OtherA: 'static + Actor + Debug + Send + Sync,
         A: 'static + Send + HandleEvent<Report<OtherA>>,
         Cfg: Into<SpawnConfig<OtherA>>,
     {
         let handle = self.handle().clone();
-        self.scope.spawn_actor_supervised(actor, handle).await
+        self.scope.spawn_actor(actor, handle).await
     }
 
     /// Get this actor's handle.

--- a/src/runtime/actor/context.rs
+++ b/src/runtime/actor/context.rs
@@ -3,7 +3,6 @@
 
 use std::{
     any::Any,
-    fmt::Debug,
     ops::{Deref, DerefMut},
     panic::AssertUnwindSafe,
     time::Duration,
@@ -44,8 +43,8 @@ impl<A: Actor> ActorContext<A> {
     /// Spawn a new supervised child actor.
     pub async fn spawn_child<OtherA, Cfg>(&mut self, actor: Cfg) -> Addr<OtherA>
     where
-        OtherA: 'static + Actor + Debug + Send + Sync,
-        A: 'static + Send + HandleEvent<Report<OtherA>>,
+        OtherA: 'static + Actor,
+        A: 'static + HandleEvent<Report<OtherA>>,
         Cfg: Into<SpawnConfig<OtherA>>,
     {
         let handle = self.handle().clone();
@@ -65,7 +64,7 @@ impl<A: Actor> ActorContext<A> {
     /// Delay the processing of an event by re-sending it to self.
     /// If a time is specified, the event will be delayed until that time,
     /// otherwise it will re-process immediately.
-    pub fn delay<E: 'static + DynEvent<A> + Send + Sync>(
+    pub fn delay<E: 'static + DynEvent<A>>(
         &self,
         event: E,
         delay: impl Into<Option<Duration>>,

--- a/src/runtime/actor/error.rs
+++ b/src/runtime/actor/error.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use thiserror::Error;
 
 use super::Actor;
@@ -14,6 +12,6 @@ pub enum ActorError<A: Actor> {
     Aborted,
     #[error("Actor panicked")]
     Panic,
-    #[error("Actor error: {0:?}")]
-    Result(Arc<A::Error>),
+    #[error("Actor error: {0}")]
+    Result(A::Error),
 }

--- a/src/runtime/actor/mod.rs
+++ b/src/runtime/actor/mod.rs
@@ -34,7 +34,7 @@ pub trait Actor: Send + Sync + Sized {
         std::any::type_name::<Self>().into()
     }
 
-    /// Start the actor. This should call `run` if the actor should process events.
+    /// Start the actor, and create the internal state.
     async fn init(&mut self, cx: &mut ActorContext<Self>) -> Result<Self::State, Self::Error>;
 
     /// Run the actor event loop

--- a/src/runtime/actor/mod.rs
+++ b/src/runtime/actor/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, error::Error, fmt::Debug};
+use std::{borrow::Cow, error::Error};
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -25,7 +25,7 @@ pub mod util;
 #[async_trait]
 pub trait Actor: Send + Sync + Sized {
     /// Custom data that is passed to all actor methods.
-    type State: Debug + Send + Sync;
+    type State: Send + Sync;
     /// Custom error type that is returned by all actor methods.
     type Error: Error + Send + Sync;
 

--- a/src/runtime/actor/mod.rs
+++ b/src/runtime/actor/mod.rs
@@ -25,9 +25,9 @@ pub mod util;
 #[async_trait]
 pub trait Actor: Send + Sync + Sized {
     /// Custom data that is passed to all actor methods.
-    type State: Send + Sync;
+    type State: Send;
     /// Custom error type that is returned by all actor methods.
-    type Error: Error + Send + Sync;
+    type Error: Error + Send;
 
     /// Set this actor's name, primarily for debugging purposes.
     fn name(&self) -> Cow<'static, str> {

--- a/src/runtime/actor/report.rs
+++ b/src/runtime/actor/report.rs
@@ -1,10 +1,11 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt::Debug;
+
 use super::{error::ActorError, Actor};
 
 /// An actor exit report.
-#[derive(Debug)]
 pub enum Report<A: Actor> {
     /// Actor exited successfully.
     Success(SuccessReport<A>),
@@ -62,8 +63,20 @@ impl<A: Actor> Report<A> {
     }
 }
 
+impl<A: Actor> Debug for Report<A>
+where
+    A: Debug,
+    A::State: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Success(arg0) => f.debug_tuple("Success").field(arg0).finish(),
+            Self::Error(arg0) => f.debug_tuple("Error").field(arg0).finish(),
+        }
+    }
+}
+
 /// A report that an actor finished running with an error
-#[derive(Debug)]
 pub struct SuccessReport<A: Actor> {
     /// The actor's external state when it finished running
     pub actor: A,
@@ -97,8 +110,20 @@ impl<A: Actor> SuccessReport<A> {
     }
 }
 
+impl<A: Actor> Debug for SuccessReport<A>
+where
+    A: Debug,
+    A::State: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SuccessReport")
+            .field("actor", &self.actor)
+            .field("internal_state", &self.internal_state)
+            .finish()
+    }
+}
+
 /// A report that an actor finished running with an error.
-#[derive(Debug)]
 pub struct ErrorReport<A: Actor> {
     /// The actor's external state when it finished running.
     pub actor: A,
@@ -145,5 +170,19 @@ impl<A: Actor> ErrorReport<A> {
     /// Takes the error that occurred.
     pub fn take_error(self) -> ActorError<A> {
         self.error
+    }
+}
+
+impl<A: Actor> Debug for ErrorReport<A>
+where
+    A: Debug,
+    A::State: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ErrorReport")
+            .field("actor", &self.actor)
+            .field("internal_state", &self.internal_state)
+            .field("error", &self.error)
+            .finish()
     }
 }

--- a/src/runtime/actor/report.rs
+++ b/src/runtime/actor/report.rs
@@ -3,8 +3,64 @@
 
 use super::{error::ActorError, Actor};
 
-/// An actor exit report
-pub type Report<A> = Result<SuccessReport<A>, ErrorReport<A>>;
+/// An actor exit report.
+#[derive(Debug)]
+pub enum Report<A: Actor> {
+    /// Actor exited successfully.
+    Success(SuccessReport<A>),
+    /// Actor exited with an error.
+    Error(ErrorReport<A>),
+}
+
+impl<A: Actor> Report<A> {
+    /// Gets the actor.
+    pub fn actor(&self) -> &A {
+        match self {
+            Report::Success(success) => success.actor(),
+            Report::Error(error) => error.actor(),
+        }
+    }
+
+    /// Takes the actor, consuming the report.
+    pub fn take_actor(self) -> A {
+        match self {
+            Report::Success(success) => success.take_actor(),
+            Report::Error(error) => error.take_actor(),
+        }
+    }
+
+    /// Gets the internal state, if any was created. No state indicates that the init method never completed.
+    pub fn internal_state(&self) -> Option<&A::State> {
+        match self {
+            Report::Success(success) => success.internal_state(),
+            Report::Error(error) => error.internal_state(),
+        }
+    }
+
+    /// Takes the internal state, if any was created. No state indicates that the init method never completed.
+    pub fn take_internal_state(self) -> Option<A::State> {
+        match self {
+            Report::Success(success) => success.take_internal_state(),
+            Report::Error(error) => error.take_internal_state(),
+        }
+    }
+
+    /// Gets the error, if any.
+    pub fn error(&self) -> Option<&ActorError<A>> {
+        match self {
+            Report::Success(_) => None,
+            Report::Error(error) => Some(error.error()),
+        }
+    }
+
+    /// Takes the error, if any.
+    pub fn take_error(self) -> Option<ActorError<A>> {
+        match self {
+            Report::Success(_) => None,
+            Report::Error(error) => Some(error.take_error()),
+        }
+    }
+}
 
 /// A report that an actor finished running with an error
 #[derive(Debug)]
@@ -16,8 +72,28 @@ pub struct SuccessReport<A: Actor> {
 }
 
 impl<A: Actor> SuccessReport<A> {
-    pub(crate) fn new(actor: A, internal_state: Option<A::State>) -> Report<A> {
-        Ok(Self { actor, internal_state })
+    pub(crate) fn new(actor: A, internal_state: Option<A::State>) -> Self {
+        Self { actor, internal_state }
+    }
+
+    /// Gets the actor.
+    pub fn actor(&self) -> &A {
+        &self.actor
+    }
+
+    /// Takes the actor, consuming the report.
+    pub fn take_actor(self) -> A {
+        self.actor
+    }
+
+    /// Gets the internal state, if any was created. No state indicates that the init method never completed.
+    pub fn internal_state(&self) -> Option<&A::State> {
+        self.internal_state.as_ref()
+    }
+
+    /// Takes the internal state, if any was created. No state indicates that the init method never completed.
+    pub fn take_internal_state(self) -> Option<A::State> {
+        self.internal_state
     }
 }
 
@@ -33,11 +109,41 @@ pub struct ErrorReport<A: Actor> {
 }
 
 impl<A: Actor> ErrorReport<A> {
-    pub(crate) fn new(actor: A, internal_state: Option<A::State>, error: ActorError<A>) -> Report<A> {
-        Err(Self {
+    pub(crate) fn new(actor: A, internal_state: Option<A::State>, error: ActorError<A>) -> Self {
+        Self {
             actor,
             internal_state,
             error,
-        })
+        }
+    }
+
+    /// Gets the actor.
+    pub fn actor(&self) -> &A {
+        &self.actor
+    }
+
+    /// Takes the actor, consuming the report.
+    pub fn take_actor(self) -> A {
+        self.actor
+    }
+
+    /// Gets the internal state, if any was created. No state indicates that the init method never completed.
+    pub fn internal_state(&self) -> Option<&A::State> {
+        self.internal_state.as_ref()
+    }
+
+    /// Takes the internal state, if any was created. No state indicates that the init method never completed.
+    pub fn take_internal_state(self) -> Option<A::State> {
+        self.internal_state
+    }
+
+    /// Gets the error that occurred.
+    pub fn error(&self) -> &ActorError<A> {
+        &self.error
+    }
+
+    /// Takes the error that occurred.
+    pub fn take_error(self) -> ActorError<A> {
+        self.error
     }
 }

--- a/src/runtime/actor/util.rs
+++ b/src/runtime/actor/util.rs
@@ -11,6 +11,7 @@ use super::{
     report::Report,
     Actor,
 };
+use crate::runtime::config::SpawnConfig;
 
 /// A wrapper that can be used to delay an event until a specified time.
 #[derive(Debug)]
@@ -32,7 +33,7 @@ impl<E> DelayedEvent<E> {
 impl<A, E> HandleEvent<DelayedEvent<E>> for A
 where
     A: 'static + Actor,
-    E: 'static + Send + Sync + Debug + DynEvent<A>,
+    E: 'static + DynEvent<A>,
 {
     async fn handle_event(
         &mut self,
@@ -52,13 +53,13 @@ where
 /// An event which will spawn a supervised actor.
 #[derive(Debug)]
 pub struct SpawnActor<A: Actor> {
-    actor: A,
+    actor: SpawnConfig<A>,
 }
 
 impl<A: Actor> SpawnActor<A> {
     /// Creates a new [`SpawnActor`] event.
-    pub fn new(actor: A) -> Self {
-        Self { actor }
+    pub fn new<Cfg: Into<SpawnConfig<A>>>(actor: Cfg) -> Self {
+        Self { actor: actor.into() }
     }
 }
 
@@ -66,7 +67,7 @@ impl<A: Actor> SpawnActor<A> {
 impl<T, A> HandleEvent<SpawnActor<A>> for T
 where
     T: 'static + Actor + HandleEvent<Report<A>>,
-    A: 'static + Actor + Debug + Send + Sync,
+    A: 'static + Actor,
 {
     async fn handle_event(
         &mut self,

--- a/src/runtime/actor/util.rs
+++ b/src/runtime/actor/util.rs
@@ -74,7 +74,7 @@ where
         event: SpawnActor<A>,
         _state: &mut Self::State,
     ) -> Result<(), Self::Error> {
-        cx.spawn_actor_supervised(event.actor).await;
+        cx.spawn_child(event.actor).await;
         Ok(())
     }
 }

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{error::Error, sync::Arc};
+use std::error::Error;
 
 use thiserror::Error;
 
@@ -13,7 +13,7 @@ pub enum RuntimeError {
     #[error("Scope {0:x} aborted")]
     AbortedScope(ScopeId),
     #[error("Actor exited with error: {0}")]
-    ActorError(Arc<dyn Error + Send + Sync>),
+    ActorError(String),
     #[error("Dependency notification canceled")]
     CanceledDepNotification,
     #[error("Invalid scope")]

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -167,21 +167,21 @@ pub struct AddressRegistry {
 }
 
 impl AddressRegistry {
-    pub fn insert<T>(&mut self, addr: Addr<T>)
+    pub fn insert<A>(&mut self, addr: Addr<A>)
     where
-        T: Actor + Send + Sync + 'static,
+        A: 'static + Actor,
     {
-        self.map.insert(TypeId::of::<T>(), Box::new(addr));
+        self.map.insert(TypeId::of::<A>(), Box::new(addr));
     }
 
-    pub fn get<T>(&self) -> OptionalAddr<T>
+    pub fn get<A>(&self) -> OptionalAddr<A>
     where
-        T: Actor + Send + Sync + 'static,
+        A: 'static + Actor,
     {
         self.map
-            .get(&TypeId::of::<T>())
+            .get(&TypeId::of::<A>())
             .and_then(|addr| addr.downcast_ref())
-            .and_then(|addr: &Addr<T>| (!addr.is_closed()).then(|| addr.clone()))
+            .and_then(|addr: &Addr<A>| (!addr.is_closed()).then(|| addr.clone()))
             .into()
     }
 }

--- a/src/runtime/scope.rs
+++ b/src/runtime/scope.rs
@@ -161,7 +161,7 @@ impl RuntimeScope {
         }: SpawnConfigInner<A>,
     ) -> (Addr<A>, ActorContext<A>, AbortRegistration)
     where
-        A: 'static + Actor + Send + Sync,
+        A: 'static + Actor,
     {
         let (abort_handle, abort_reg) = AbortHandle::new_pair();
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel::<Envelope<A>>();
@@ -187,7 +187,7 @@ impl RuntimeScope {
     /// Spawns a new actor with a supervisor handle.
     pub async fn spawn_actor<A, Cfg, Sup>(&mut self, actor: Cfg, supervisor_addr: Addr<Sup>) -> Addr<A>
     where
-        A: 'static + Actor + Debug + Send + Sync,
+        A: 'static + Actor,
         Sup: 'static + HandleEvent<Report<A>>,
         Cfg: Into<SpawnConfig<A>>,
     {
@@ -232,7 +232,7 @@ impl RuntimeScope {
     /// Spawns a new actor with no supervisor.
     pub async fn spawn_actor_unsupervised<A, Cfg>(&mut self, actor: Cfg) -> Addr<A>
     where
-        A: 'static + Actor + Send + Sync,
+        A: 'static + Actor,
         Cfg: Into<SpawnConfig<A>>,
     {
         let SpawnConfig { mut actor, config } = actor.into();

--- a/src/runtime/scope.rs
+++ b/src/runtime/scope.rs
@@ -1,18 +1,18 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{error::Error, fmt::Debug, ops::Deref, panic::AssertUnwindSafe, sync::Arc};
+use std::{error::Error, fmt::Debug, ops::Deref};
 
 use futures::{
     future::{AbortHandle, AbortRegistration, Abortable},
-    Future, FutureExt,
+    Future,
 };
 use tokio::task::JoinHandle;
 use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
 
 use super::{
     actor::{
-        addr::Addr,
+        addr::{Addr, OptionalAddr},
         context::ActorContext,
         event::{EnvelopeStream, HandleEvent},
         report::{Report, SuccessReport},
@@ -75,6 +75,12 @@ impl ScopeView {
     /// Finds a scope by id.
     pub fn find_by_id(&self, scope_id: ScopeId) -> Option<ScopeView> {
         self.0.find(scope_id).cloned().map(ScopeView)
+    }
+
+    /// Searches for an address for the given actor type
+    /// and returns an optional result.
+    pub async fn addr<A: 'static + Actor>(&self) -> OptionalAddr<A> {
+        self.0.get_addr().await
     }
 
     /// Shuts down the scope.
@@ -146,43 +152,6 @@ impl RuntimeScope {
         self.0.drop().await;
     }
 
-    /// Spawns a new, plain task.
-    pub async fn spawn_task<T, F>(&mut self, f: T) -> AbortHandle
-    where
-        T: Send + FnOnce(&mut RuntimeScope) -> F,
-        F: 'static + Future<Output = Result<(), Box<dyn Error + Send + Sync>>> + Send,
-    {
-        let (abort_handle, abort_registration) = AbortHandle::new_pair();
-        let mut child_scope = self.child(None, Some(abort_handle.clone())).await;
-        let fut = f(&mut child_scope);
-        let child_task = tokio::spawn(async move {
-            let res = Abortable::new(AssertUnwindSafe(fut).catch_unwind(), abort_registration).await;
-            child_scope.abort().await;
-            child_scope.join().await;
-            match res {
-                Ok(res) => match res {
-                    Ok(res) => match res {
-                        Ok(_) => Ok(()),
-                        Err(e) => {
-                            log::error!(
-                                "{} exited with error: {}",
-                                format!("Task {:x}", child_scope.id().as_fields().0),
-                                e
-                            );
-                            Err(RuntimeError::TaskError(e))
-                        }
-                    },
-                    Err(e) => {
-                        std::panic::resume_unwind(e);
-                    }
-                },
-                Err(_) => Err(RuntimeError::AbortedScope(child_scope.id())),
-            }
-        });
-        self.join_handles.push(child_task);
-        abort_handle
-    }
-
     async fn common_spawn<A>(
         &mut self,
         actor: &A,
@@ -204,13 +173,14 @@ impl RuntimeScope {
         };
         let scope = self.child(Some(shutdown_handle), Some(abort_handle)).await;
         let handle = Addr::new(scope.scope.clone(), sender);
+        self.scope.0.insert_addr(handle.clone()).await;
         let cx = ActorContext::new(scope, handle.clone(), receiver);
         log::debug!("Initializing {}", actor.name());
         (handle, cx, abort_reg)
     }
 
     /// Spawns a new actor with a supervisor handle.
-    pub async fn spawn_actor_supervised<A, Cfg, Sup>(&mut self, actor: Cfg, supervisor_addr: Addr<Sup>) -> Addr<A>
+    pub async fn spawn_actor<A, Cfg, Sup>(&mut self, actor: Cfg, supervisor_addr: Addr<Sup>) -> Addr<A>
     where
         A: 'static + Actor + Debug + Send + Sync,
         Sup: 'static + HandleEvent<Report<A>>,
@@ -225,23 +195,27 @@ impl RuntimeScope {
                 Ok(res) => match res {
                     Ok(res) => match res {
                         Ok(_) => {
-                            supervisor_addr.send(SuccessReport::new(actor, data))?;
+                            supervisor_addr.send(Report::Success(SuccessReport::new(actor, data)))?;
                             Ok(())
                         }
                         Err(e) => {
                             log::error!("{} exited with error: {}", actor.name(), e);
-                            let e = Arc::new(e);
-                            supervisor_addr.send(ErrorReport::new(actor, data, ActorError::Result(e.clone())))?;
-                            Err(RuntimeError::ActorError(e))
+                            let err_str = e.to_string();
+                            supervisor_addr.send(Report::Error(ErrorReport::new(
+                                actor,
+                                data,
+                                ActorError::Result(e),
+                            )))?;
+                            Err(RuntimeError::ActorError(err_str))
                         }
                     },
                     Err(e) => {
-                        supervisor_addr.send(ErrorReport::new(actor, data, ActorError::Panic))?;
+                        supervisor_addr.send(Report::Error(ErrorReport::new(actor, data, ActorError::Panic)))?;
                         std::panic::resume_unwind(e);
                     }
                 },
                 Err(_) => {
-                    supervisor_addr.send(ErrorReport::new(actor, data, ActorError::Aborted))?;
+                    supervisor_addr.send(Report::Error(ErrorReport::new(actor, data, ActorError::Aborted)))?;
                     Err(RuntimeError::AbortedScope(cx.scope.id()))
                 }
             }
@@ -251,7 +225,7 @@ impl RuntimeScope {
     }
 
     /// Spawns a new actor with no supervisor.
-    pub async fn spawn_actor<A, Cfg>(&mut self, actor: Cfg) -> Addr<A>
+    pub async fn spawn_actor_unsupervised<A, Cfg>(&mut self, actor: Cfg) -> Addr<A>
     where
         A: 'static + Actor + Send + Sync,
         Cfg: Into<SpawnConfig<A>>,
@@ -267,7 +241,7 @@ impl RuntimeScope {
                         Ok(_) => Ok(()),
                         Err(e) => {
                             log::error!("{} exited with error: {}", actor.name(), e);
-                            Err(RuntimeError::ActorError(Arc::new(e)))
+                            Err(RuntimeError::ActorError(e.to_string()))
                         }
                     },
                     Err(e) => {


### PR DESCRIPTION
This solves two problems:
1. The registry is now scoped along with the actors, so hierarchical design can be maintained.
2. Spawning actors now automatically adds the address to the registry (unless specified otherwise) so the `SpawnActor` event does not need to do anything special.