### PR TITLE
feat(runtime)!: make actors abortable from init

### DIFF
--- a/bin/inx-chronicle/src/api/mod.rs
+++ b/bin/inx-chronicle/src/api/mod.rs
@@ -107,7 +107,7 @@ impl Actor for ApiWorker {
                 .with_graceful_shutdown(shutdown_signal(receiver))
                 .await;
             // If the Axum server shuts down, we should also shutdown the API actor
-            api_handle.shutdown();
+            api_handle.shutdown().await;
             res
         });
         self.server_handle = Some((join_handle, sender));

--- a/bin/inx-chronicle/src/metrics.rs
+++ b/bin/inx-chronicle/src/metrics.rs
@@ -115,7 +115,7 @@ impl Actor for MetricsWorker {
                 };
 
                 // Stop the actor if the server stops.
-                metrics_handle.shutdown();
+                metrics_handle.shutdown().await;
 
                 res.unwrap()
             })

--- a/bin/inx-chronicle/src/stardust_inx/config.rs
+++ b/bin/inx-chronicle/src/stardust_inx/config.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use chronicle::types::tangle::MilestoneIndex;
 use serde::{Deserialize, Serialize};
 
-/// A builder to establish a connection to INX.
+/// Configuration for an INX connection.
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct InxConfig {
@@ -15,7 +15,9 @@ pub struct InxConfig {
     /// The time that has to pass until a new connection attempt is made.
     #[serde(with = "humantime_serde")]
     pub connection_retry_interval: Duration,
+    /// The number of retries when connecting fails.
     pub connection_retry_count: usize,
+    /// The milestone at which synchronization should begin.
     pub sync_start_milestone: MilestoneIndex,
 }
 

--- a/bin/inx-chronicle/src/stardust_inx/config.rs
+++ b/bin/inx-chronicle/src/stardust_inx/config.rs
@@ -15,7 +15,7 @@ pub struct InxConfig {
     /// The time that has to pass until a new connection attempt is made.
     #[serde(with = "humantime_serde")]
     pub connection_retry_interval: Duration,
-    pub connection_retry_count: u32,
+    pub connection_retry_count: usize,
     pub sync_start_milestone: MilestoneIndex,
 }
 

--- a/bin/inx-chronicle/src/stardust_inx/config.rs
+++ b/bin/inx-chronicle/src/stardust_inx/config.rs
@@ -7,7 +7,6 @@ use chronicle::types::tangle::MilestoneIndex;
 use serde::{Deserialize, Serialize};
 
 /// A builder to establish a connection to INX.
-#[must_use]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct InxConfig {
@@ -16,6 +15,7 @@ pub struct InxConfig {
     /// The time that has to pass until a new connection attempt is made.
     #[serde(with = "humantime_serde")]
     pub connection_retry_interval: Duration,
+    pub connection_retry_count: u32,
     pub sync_start_milestone: MilestoneIndex,
 }
 
@@ -24,6 +24,7 @@ impl Default for InxConfig {
         Self {
             connect_url: "http://localhost:9029".into(),
             connection_retry_interval: Duration::from_secs(5),
+            connection_retry_count: 5,
             sync_start_milestone: 1.into(),
         }
     }

--- a/bin/inx-chronicle/src/stardust_inx/mod.rs
+++ b/bin/inx-chronicle/src/stardust_inx/mod.rs
@@ -46,17 +46,15 @@ impl InxWorker {
             return Err(InxError::InvalidAddress(inx_config.connect_url.clone()));
         }
 
-        let mut retries = inx_config.connection_retry_count;
-
-        while retries > 0 {
+        for i in 0..inx_config.connection_retry_count {
             match InxClient::connect(inx_config.connect_url.clone()).await {
                 Ok(inx_client) => return Ok(inx_client),
                 Err(_) => {
                     log::warn!(
-                        "INX connection failed. Retrying in {}s.",
-                        inx_config.connection_retry_interval.as_secs()
+                        "INX connection failed. Retrying in {}s. {} retries remaining.",
+                        inx_config.connection_retry_interval.as_secs(),
+                        inx_config.connection_retry_count - i
                     );
-                    retries -= 1;
                     tokio::time::sleep(inx_config.connection_retry_interval).await;
                 }
             }

--- a/bin/inx-chronicle/src/stardust_inx/syncer.rs
+++ b/bin/inx-chronicle/src/stardust_inx/syncer.rs
@@ -120,7 +120,7 @@ impl HandleEvent<SyncNext> for Syncer {
             .await;
         } else {
             log::info!("Successfully finished synchronization with node.");
-            cx.shutdown();
+            cx.shutdown().await;
         }
         Ok(())
     }

--- a/src/runtime/actor/addr.rs
+++ b/src/runtime/actor/addr.rs
@@ -41,8 +41,8 @@ impl<A: Actor> Addr<A> {
     }
 
     /// Shuts down the actor. Use with care!
-    pub fn shutdown(&self) {
-        self.scope.shutdown();
+    pub async fn shutdown(&self) {
+        self.scope.shutdown().await;
     }
 
     /// Aborts the actor. Use with care!


### PR DESCRIPTION
Previously, an aborted actor would try to exit via the shutdown handle, but this would not abort if the actor is waiting in `init`. This change avoid using the shutdown handle until the actor has completed `init`, thus the abort handle is used instead during that time.