### PR TITLE
feat(config): set `api`, `inx`, `metrics` features dynamically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "bin/inx-chronicle/src/main.rs"
 # Required
 async-recursion = { version = "1.0", default-features = false }
 async-trait = { version = "0.1", default-features = false }
-clap = { version = "3.1", default-features = false, features = [ "derive", "std" ] }
+clap = { version = "3.1", default-features = false, features = [ "env", "derive", "std" ] }
 derive_more = { version = "0.99", default-features = false, features = [ "add", "add_assign", "deref", "deref_mut" ] }
 dotenv = { version = "0.15", default-features = false }
 dyn-clone = { version = "1.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -97,3 +97,12 @@ The `sub` (subject) claim is filled using a unique UUID, however it is not curre
 ### Providing a Token
 
 To provide a token when making a request, include it in an `Authorization` header using the `Bearer` authentication scheme.
+
+### Environment Variables
+
+Currently Chronicle supports the following environment variables:
+
+CONFIG_PATH="<FILE_PATH>": sets the file path to the `config.toml` file;
+INX=<true|false>: enables/disables INX;
+API=<true|false>: enables/disables REST API;
+METRICS=<true|false>: enables/disables the Metrics Server;

--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ Currently Chronicle supports the following environment variables:
 
 CONFIG_PATH="<FILE_PATH>": sets the file path to the `config.toml` file;
 INX=<true|false>: enables/disables INX;
-API=<true|false>: enables/disables REST API;
+API=<true|false>: enables/disables the REST API;
 METRICS=<true|false>: enables/disables the Metrics Server;

--- a/bin/inx-chronicle/config.template.toml
+++ b/bin/inx-chronicle/config.template.toml
@@ -1,4 +1,5 @@
 [mongodb]
+
 ### Listening address of the MongoDB instance.
 connect_url = "mongodb://localhost:27017"
 
@@ -11,6 +12,7 @@ password = "root"
 database_name = "chronicle"
 
 [api]
+
 ### Whether API requests will be served.
 enabled = true
 
@@ -37,6 +39,10 @@ public_routes = [
 ]
 
 [inx]
+
+### Whether INX is used (online mode).
+enabled = true
+
 ### Listening address of the node's INX interface.
 connect_url = "http://localhost:9029"
 
@@ -46,18 +52,16 @@ connection_retry_interval = "5s"
 ### Maximum number of tries to establish an INX connection.
 connection_retry_count = 10
 
-### Whether INX is used (online mode).
-enabled = true
-
 ### Milestone at which synchronization should begin. A value of `1` means syncing back until genesis.
 sync_start_milestone = 1 
 
 [metrics]
-### Bind address of the metrics server.
-address = "0.0.0.0"
 
 ### Whether metrics will be served.
 enabled = true
+
+### Bind address of the metrics server.
+address = "0.0.0.0"
 
 ### Bind port of the metrics server.
 port = 9100

--- a/bin/inx-chronicle/config.template.toml
+++ b/bin/inx-chronicle/config.template.toml
@@ -11,6 +11,9 @@ password = "root"
 database_name = "chronicle"
 
 [api]
+### Whether API requests will be served.
+enabled = true
+
 ### API listening port. 
 port = 8042
 
@@ -43,12 +46,18 @@ connection_retry_interval = "5s"
 ### Maximum number of tries to establish an INX connection.
 connection_retry_count = 10
 
+### Whether INX is used (online mode).
+enabled = true
+
 ### Milestone at which synchronization should begin. A value of `1` means syncing back until genesis.
 sync_start_milestone = 1 
 
 [metrics]
 ### Bind address of the metrics server.
 address = "0.0.0.0"
+
+### Whether metrics will be served.
+enabled = true
 
 ### Bind port of the metrics server.
 port = 9100

--- a/bin/inx-chronicle/config.template.toml
+++ b/bin/inx-chronicle/config.template.toml
@@ -1,5 +1,4 @@
 [mongodb]
-
 ### Listening address of the MongoDB instance.
 connect_url = "mongodb://localhost:27017"
 
@@ -12,7 +11,6 @@ password = "root"
 database_name = "chronicle"
 
 [api]
-
 ### Whether API requests will be served.
 enabled = true
 
@@ -39,7 +37,6 @@ public_routes = [
 ]
 
 [inx]
-
 ### Whether INX is used (online mode).
 enabled = true
 
@@ -56,7 +53,6 @@ connection_retry_count = 10
 sync_start_milestone = 1 
 
 [metrics]
-
 ### Whether metrics will be served.
 enabled = true
 

--- a/bin/inx-chronicle/src/api/config.rs
+++ b/bin/inx-chronicle/src/api/config.rs
@@ -14,6 +14,7 @@ use super::{error::ConfigError, SecretKey};
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ApiConfig {
+    pub enabled: bool,
     pub port: u16,
     pub allow_origins: SingleOrMultiple<String>,
     pub password_hash: String,
@@ -27,6 +28,7 @@ pub struct ApiConfig {
 impl Default for ApiConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             port: 8042,
             allow_origins: "*".to_string().into(),
             password_hash: "c42cf2be3a442a29d8cd827a27099b0c".to_string(),

--- a/bin/inx-chronicle/src/cli.rs
+++ b/bin/inx-chronicle/src/cli.rs
@@ -17,9 +17,9 @@ pub struct ClArgs {
     #[clap(long = "inx")]
     pub inx_addr: Option<String>,
     /// Toggle INX (offline mode).
-    #[clap(long, value_parser, env = "INX", default_value = "true")]
+    #[clap(long, value_parser, default_value = "true", env = "INX")]
     #[cfg(feature = "inx")]
-    pub toggle_inx: bool,
+    pub enable_inx: bool,
     /// The location of the identity file for JWT auth.
     #[clap(long)]
     pub identity: Option<String>,
@@ -27,11 +27,11 @@ pub struct ClArgs {
     #[clap(long)]
     pub password: Option<String>,
     /// Toggle REST API.
-    #[clap(long, value_parser, env = "API", default_value = "true")]
+    #[clap(long, value_parser, default_value = "true", env = "API")]
     #[cfg(feature = "api")]
-    pub toggle_api: bool,
+    pub enable_api: bool,
     /// Toggle the metrics server.
-    #[clap(long, value_parser, env = "METRICS", default_value = "true")]
+    #[clap(long, value_parser, default_value = "true", env = "METRICS")]
     #[cfg(feature = "metrics")]
-    pub toggle_metrics: bool,
+    pub enable_metrics: bool,
 }

--- a/bin/inx-chronicle/src/cli.rs
+++ b/bin/inx-chronicle/src/cli.rs
@@ -18,6 +18,7 @@ pub struct ClArgs {
     pub inx_addr: Option<String>,
     /// Toggle INX (offline mode).
     #[clap(long, value_parser, env = "INX", default_value = "true")]
+    #[cfg(feature = "inx")]
     pub toggle_inx: bool,
     /// The location of the identity file for JWT auth.
     #[clap(long)]
@@ -27,8 +28,10 @@ pub struct ClArgs {
     pub password: Option<String>,
     /// Toggle REST API.
     #[clap(long, value_parser, env = "API", default_value = "true")]
+    #[cfg(feature = "api")]
     pub toggle_api: bool,
     /// Toggle the metrics server.
     #[clap(long, value_parser, env = "METRICS", default_value = "true")]
+    #[cfg(feature = "metrics")]
     pub toggle_metrics: bool,
 }

--- a/bin/inx-chronicle/src/cli.rs
+++ b/bin/inx-chronicle/src/cli.rs
@@ -6,20 +6,29 @@ use clap::Parser;
 /// Chronicle permanode storage as an INX plugin
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
-pub struct CliArgs {
+pub struct ClArgs {
     /// The location of the configuration file.
-    #[clap(short, value_parser, long)]
+    #[clap(short, long)]
     pub config: Option<String>,
-    /// The address of the INX interface provided by the node.
-    #[clap(value_parser, long)]
-    pub inx: Option<String>,
     /// The address of the MongoDB database.
-    #[clap(value_parser, long)]
-    pub db: Option<String>,
+    #[clap(long = "db")]
+    pub db_addr: Option<String>,
+    /// The address of the INX interface provided by the node.
+    #[clap(long = "inx")]
+    pub inx_addr: Option<String>,
+    /// Toggle INX (offline mode).
+    #[clap(long, value_parser, env = "INX", default_value = "true")]
+    pub toggle_inx: bool,
     /// The location of the identity file for JWT auth.
-    #[clap(value_parser, long)]
+    #[clap(long)]
     pub identity: Option<String>,
     /// The password used for authentication.
-    #[clap(value_parser, long)]
+    #[clap(long)]
     pub password: Option<String>,
+    /// Toggle REST API.
+    #[clap(long, value_parser, env = "API", default_value = "true")]
+    pub toggle_api: bool,
+    /// Toggle the metrics server.
+    #[clap(long, value_parser, env = "METRICS", default_value = "true")]
+    pub toggle_metrics: bool,
 }

--- a/bin/inx-chronicle/src/config.rs
+++ b/bin/inx-chronicle/src/config.rs
@@ -32,19 +32,20 @@ pub struct ChronicleConfig {
 }
 
 impl ChronicleConfig {
+    /// Reads the config from the file located at `path`.
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
         fs::read_to_string(&path)
             .map_err(|e| ConfigError::FileRead(path.as_ref().display().to_string(), e))
             .and_then(|contents| toml::from_str::<Self>(&contents).map_err(ConfigError::TomlDeserialization))
     }
 
-    /// Applies the appropriate command line arguments to the [`ChronicleConfig`].
-    pub fn apply_cli_args(&mut self, args: &super::cli::CliArgs) {
-        if let Some(connect_url) = &args.db {
+    /// Applies command line arguments to the config.
+    pub fn apply_cl_args(&mut self, args: &super::cli::ClArgs) {
+        if let Some(connect_url) = &args.db_addr {
             self.mongodb = MongoDbConfig::new().with_connect_url(connect_url);
         }
         #[cfg(all(feature = "stardust", feature = "inx"))]
-        if let Some(inx) = &args.inx {
+        if let Some(inx) = &args.inx_addr {
             self.inx.connect_url = inx.clone();
         }
         #[cfg(feature = "api")]

--- a/bin/inx-chronicle/src/config.rs
+++ b/bin/inx-chronicle/src/config.rs
@@ -45,19 +45,28 @@ impl ChronicleConfig {
             self.mongodb = MongoDbConfig::new().with_connect_url(connect_url);
         }
         #[cfg(all(feature = "stardust", feature = "inx"))]
-        if let Some(inx) = &args.inx_addr {
-            self.inx.connect_url = inx.clone();
+        {
+            if let Some(inx) = &args.inx_addr {
+                self.inx.connect_url = inx.clone();
+            }
+            self.inx.enabled = args.toggle_inx;
         }
         #[cfg(feature = "api")]
-        if let Some(password) = &args.password {
-            self.api.password_hash = hex::encode(
-                auth_helper::password::password_hash(password.as_bytes(), self.api.password_salt.as_bytes())
-                    .expect("invalid JWT config"),
-            );
+        {
+            if let Some(password) = &args.password {
+                self.api.password_hash = hex::encode(
+                    auth_helper::password::password_hash(password.as_bytes(), self.api.password_salt.as_bytes())
+                        .expect("invalid JWT config"),
+                );
+            }
+            if let Some(path) = &args.identity {
+                self.api.identity_path.replace(path.clone());
+            }
+            self.api.enabled = args.toggle_api;
         }
-        #[cfg(feature = "api")]
-        if let Some(path) = &args.identity {
-            self.api.identity_path.replace(path.clone());
+        #[cfg(feature = "metrics")]
+        {
+            self.metrics.enabled = args.toggle_metrics;
         }
     }
 }

--- a/bin/inx-chronicle/src/config.rs
+++ b/bin/inx-chronicle/src/config.rs
@@ -49,7 +49,7 @@ impl ChronicleConfig {
             if let Some(inx) = &args.inx_addr {
                 self.inx.connect_url = inx.clone();
             }
-            self.inx.enabled = args.toggle_inx;
+            self.inx.enabled = args.enable_inx;
         }
         #[cfg(feature = "api")]
         {
@@ -62,11 +62,11 @@ impl ChronicleConfig {
             if let Some(path) = &args.identity {
                 self.api.identity_path.replace(path.clone());
             }
-            self.api.enabled = args.toggle_api;
+            self.api.enabled = args.enable_api;
         }
         #[cfg(feature = "metrics")]
         {
-            self.metrics.enabled = args.toggle_metrics;
+            self.metrics.enabled = args.enable_metrics;
         }
     }
 }

--- a/bin/inx-chronicle/src/launcher.rs
+++ b/bin/inx-chronicle/src/launcher.rs
@@ -54,16 +54,22 @@ impl Actor for Launcher {
         db.create_milestone_indexes().await?;
 
         #[cfg(all(feature = "inx", feature = "stardust"))]
-        cx.spawn_child(super::stardust_inx::InxWorker::new(&db, &config.inx))
-            .await;
+        if config.inx.enabled {
+            cx.spawn_child(super::stardust_inx::InxWorker::new(&db, &config.inx))
+                .await;
+        }
 
         #[cfg(feature = "api")]
-        cx.spawn_child(super::api::ApiWorker::new(&db, &config.api).map_err(ConfigError::Api)?)
-            .await;
+        if config.api.enabled {
+            cx.spawn_child(super::api::ApiWorker::new(&db, &config.api).map_err(ConfigError::Api)?)
+                .await;
+        }
 
         #[cfg(feature = "metrics")]
-        cx.spawn_child(super::metrics::MetricsWorker::new(&db, &config.metrics))
-            .await;
+        if config.metrics.enabled {
+            cx.spawn_child(super::metrics::MetricsWorker::new(&db, &config.metrics))
+                .await;
+        }
 
         Ok(config)
     }

--- a/bin/inx-chronicle/src/stardust_inx/config.rs
+++ b/bin/inx-chronicle/src/stardust_inx/config.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct InxConfig {
+    pub enabled: bool,
     /// The bind address of node's INX interface.
     pub connect_url: String,
     /// The time that has to pass until a new connection attempt is made.
@@ -24,6 +25,7 @@ pub struct InxConfig {
 impl Default for InxConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             connect_url: "http://localhost:9029".into(),
             connection_retry_interval: Duration::from_secs(5),
             connection_retry_count: 5,


### PR DESCRIPTION
- [x] configuration through `config.toml`
- [x] configuration through `.env` file

The override order is as follows (from lowest to highest priority):
- `config.toml` file
- `.env` file
- CLI parameter

NOTE: the features (api/inx/metrics) have to be compiled into the binary. For features that aren't there the flags will just be ignored.

Closes #387.