### PR TITLE
feat(syncer): report syncing progress by milestone range

### DIFF
--- a/bin/inx-chronicle/config.template.toml
+++ b/bin/inx-chronicle/config.template.toml
@@ -55,6 +55,9 @@ connection_retry_count = 10
 ### Milestone at which synchronization should begin. A value of `1` means syncing back until genesis.
 sync_start_milestone = 1 
 
+### Number of milestones to sync at a time. This will report progress in this batch size to INFO level logs.
+sync_batch_size = 100
+
 [metrics]
 ### Whether metrics will be served.
 enabled = true

--- a/bin/inx-chronicle/src/stardust_inx/config.rs
+++ b/bin/inx-chronicle/src/stardust_inx/config.rs
@@ -20,6 +20,8 @@ pub struct InxConfig {
     pub connection_retry_count: usize,
     /// The milestone at which synchronization should begin.
     pub sync_start_milestone: MilestoneIndex,
+    /// The number of milestones to sync at a time. Will default to gap size.
+    pub sync_batch_size: Option<u32>,
 }
 
 impl Default for InxConfig {
@@ -30,6 +32,7 @@ impl Default for InxConfig {
             connection_retry_interval: Duration::from_secs(5),
             connection_retry_count: 5,
             sync_start_milestone: 1.into(),
+            sync_batch_size: None,
         }
     }
 }

--- a/bin/inx-chronicle/src/stardust_inx/ledger_update_stream.rs
+++ b/bin/inx-chronicle/src/stardust_inx/ledger_update_stream.rs
@@ -20,7 +20,7 @@ use super::{cone_stream::ConeStream, InxError};
 pub struct LedgerUpdateStream {
     db: MongoDb,
     inx: InxClient<Channel>,
-    range: RangeInclusive<MilestoneIndex>,
+    pub(crate) range: RangeInclusive<MilestoneIndex>,
 }
 
 impl LedgerUpdateStream {

--- a/bin/inx-chronicle/src/stardust_inx/mod.rs
+++ b/bin/inx-chronicle/src/stardust_inx/mod.rs
@@ -103,7 +103,12 @@ impl InxWorker {
             .gaps;
         if !sync_data.is_empty() {
             let syncer = cx
-                .spawn_child(Syncer::new(sync_data, self.db.clone(), inx_client.clone()))
+                .spawn_child(Syncer::new(
+                    sync_data,
+                    self.db.clone(),
+                    inx_client.clone(),
+                    &self.config,
+                ))
                 .await;
             syncer.send(SyncNext)?;
         } else {

--- a/bin/inx-chronicle/src/stardust_inx/syncer.rs
+++ b/bin/inx-chronicle/src/stardust_inx/syncer.rs
@@ -11,7 +11,7 @@ use chronicle::{
 };
 use inx::{client::InxClient, tonic::Channel};
 
-use super::{InxError, LedgerUpdateStream};
+use super::{InxConfig, InxError, LedgerUpdateStream};
 
 // The Syncer starts at a certain milestone index in the past and moves forwards in time trying to sync as many
 // milestones as possible - including their cones.
@@ -22,9 +22,17 @@ pub struct Syncer {
 }
 
 impl Syncer {
-    pub fn new(gaps: Vec<RangeInclusive<MilestoneIndex>>, db: MongoDb, inx_client: InxClient<Channel>) -> Self {
+    pub fn new(
+        gaps: Vec<RangeInclusive<MilestoneIndex>>,
+        db: MongoDb,
+        inx_client: InxClient<Channel>,
+        config: &InxConfig,
+    ) -> Self {
         Self {
-            gaps: Gaps(gaps.into()),
+            gaps: Gaps {
+                gaps: gaps.into(),
+                batch_size: config.sync_batch_size.map(|v| v.max(1)), // Minimum of 1 at a time
+            },
             db,
             inx_client,
         }
@@ -32,15 +40,27 @@ impl Syncer {
 }
 
 #[derive(Debug, Default)]
-pub struct Gaps(VecDeque<RangeInclusive<MilestoneIndex>>);
+pub struct Gaps {
+    gaps: VecDeque<RangeInclusive<MilestoneIndex>>,
+    batch_size: Option<u32>,
+}
 
 impl Iterator for Gaps {
     type Item = RangeInclusive<MilestoneIndex>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(range) = self.0.pop_front() {
+        while let Some(range) = self.gaps.pop_front() {
             if range.start() <= range.end() {
-                return Some(range);
+                if let Some(batch_size) = self.batch_size {
+                    let batch_end = (*range.end()).min(*range.start() + MilestoneIndex(batch_size - 1));
+                    let res = *range.start()..=batch_end;
+                    if batch_end < *range.end() {
+                        self.gaps.push_front(batch_end + 1..=*range.end());
+                    }
+                    return Some(res);
+                } else {
+                    return Some(range);
+                }
             }
         }
         None
@@ -72,7 +92,13 @@ impl HandleEvent<Report<LedgerUpdateStream>> for Syncer {
         // Start syncing the next milestone range
         cx.delay(SyncNext, None)?;
         match event {
-            Report::Success(_) => (),
+            Report::Success(report) => {
+                log::info!(
+                    "Synced milestones {}..={}",
+                    report.actor.range.start(),
+                    report.actor.range.end()
+                );
+            }
             Report::Error(report) => match report.error {
                 ActorError::Result(e) => {
                     Err(e)?;


### PR DESCRIPTION
```
[2022-07-12T13:42:58Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 72201..72300.
[2022-07-12T13:43:10Z INFO  inx_chronicle::stardust_inx::syncer] Synced milestones 72201..=72300
[2022-07-12T13:43:10Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 72301..72400.
[2022-07-12T13:43:22Z INFO  inx_chronicle::stardust_inx::syncer] Synced milestones 72301..=72400
[2022-07-12T13:43:22Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 72401..72500.
[2022-07-12T13:43:34Z INFO  inx_chronicle::stardust_inx::syncer] Synced milestones 72401..=72500
[2022-07-12T13:43:34Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 72501..72600.
[2022-07-12T13:43:46Z INFO  inx_chronicle::stardust_inx::syncer] Synced milestones 72501..=72600
[2022-07-12T13:43:46Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 72601..72700.
[2022-07-12T13:43:59Z INFO  inx_chronicle::stardust_inx::syncer] Synced milestones 72601..=72700
[2022-07-12T13:43:59Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 72701..72800.
[2022-07-12T13:44:11Z INFO  inx_chronicle::stardust_inx::syncer] Synced milestones 72701..=72800
[2022-07-12T13:44:11Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 72801..72866.
[2022-07-12T13:44:19Z INFO  inx_chronicle::stardust_inx::syncer] Synced milestones 72801..=72866
[2022-07-12T13:44:19Z INFO  inx_chronicle::stardust_inx::syncer] Successfully finished synchronization with node.
```