### PR TITLE
feat(syncer): report syncing progress at intervals

### DIFF
--- a/bin/inx-chronicle/config.template.toml
+++ b/bin/inx-chronicle/config.template.toml
@@ -53,7 +53,10 @@ connection_retry_interval = "5s"
 connection_retry_count = 10
 
 ### Milestone at which synchronization should begin. A value of `1` means syncing back until genesis.
-sync_start_milestone = 1 
+sync_start_milestone = 1
+
+### The interval at which to report syncing progress.
+sync_report_interval = "5s"
 
 [metrics]
 ### Whether metrics will be served.

--- a/bin/inx-chronicle/src/stardust_inx/config.rs
+++ b/bin/inx-chronicle/src/stardust_inx/config.rs
@@ -20,6 +20,8 @@ pub struct InxConfig {
     pub connection_retry_count: usize,
     /// The milestone at which synchronization should begin.
     pub sync_start_milestone: MilestoneIndex,
+    /// The interval at which to report syncing progress.
+    pub sync_report_interval: Duration,
 }
 
 impl Default for InxConfig {
@@ -30,6 +32,7 @@ impl Default for InxConfig {
             connection_retry_interval: Duration::from_secs(5),
             connection_retry_count: 5,
             sync_start_milestone: 1.into(),
+            sync_report_interval: Duration::from_secs(5),
         }
     }
 }

--- a/bin/inx-chronicle/src/stardust_inx/mod.rs
+++ b/bin/inx-chronicle/src/stardust_inx/mod.rs
@@ -25,7 +25,7 @@ use inx::{
 pub use ledger_update_stream::LedgerUpdateStream;
 
 use self::syncer::{SyncNext, Syncer};
-use crate::check_health::IsHealthy;
+use crate::{check_health::IsHealthy, stardust_inx::syncer::SyncProgress};
 
 pub struct InxWorker {
     db: MongoDb,
@@ -105,6 +105,7 @@ impl InxWorker {
             let syncer = cx
                 .spawn_child(Syncer::new(sync_data, self.db.clone(), inx_client.clone()))
                 .await;
+            syncer.send(SyncProgress(self.config.sync_report_interval))?;
             syncer.send(SyncNext)?;
         } else {
             cx.abort().await;

--- a/src/db/collections/milestone.rs
+++ b/src/db/collections/milestone.rs
@@ -63,6 +63,29 @@ pub struct SyncData {
     pub gaps: Vec<RangeInclusive<MilestoneIndex>>,
 }
 
+impl std::fmt::Display for SyncData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sync Data")
+            .field(
+                "completed",
+                &self
+                    .completed
+                    .iter()
+                    .map(|r| format!("{}..={}", r.start(), r.end()))
+                    .collect::<Vec<_>>(),
+            )
+            .field(
+                "gaps",
+                &self
+                    .gaps
+                    .iter()
+                    .map(|r| format!("{}..={}", r.start(), r.end()))
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
 impl MongoDb {
     /// Creates ledger update indexes.
     pub async fn create_milestone_indexes(&self) -> Result<(), Error> {

--- a/src/runtime/actor/util.rs
+++ b/src/runtime/actor/util.rs
@@ -44,7 +44,7 @@ where
         let handle = cx.handle().clone();
         spawn_task("delay event sleeper", async move {
             tokio::time::sleep(event.delay).await;
-            handle.send(event.event).unwrap();
+            handle.send(event.event).ok();
         });
         Ok(())
     }


### PR DESCRIPTION
```
[2022-07-12T14:37:53Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 73315..73479.
[2022-07-12T14:37:55Z INFO  inx_chronicle::stardust_inx::syncer] Sync Data {
        completed: [
            "72201..=73329",
            "73480..=73481",
            "73510..=73525",
        ],
        gaps: [
            "73330..=73479",
            "73482..=73509",
        ],
    }
[2022-07-12T14:38:00Z INFO  inx_chronicle::stardust_inx::syncer] Sync Data {
        completed: [
            "72201..=73372",
            "73480..=73481",
            "73510..=73526",
        ],
        gaps: [
            "73373..=73479",
            "73482..=73509",
        ],
    }
[2022-07-12T14:38:05Z INFO  inx_chronicle::stardust_inx::syncer] Sync Data {
        completed: [
            "72201..=73415",
            "73480..=73481",
            "73510..=73527",
        ],
        gaps: [
            "73416..=73479",
            "73482..=73509",
        ],
    }
[2022-07-12T14:38:10Z INFO  inx_chronicle::stardust_inx::syncer] Sync Data {
        completed: [
            "72201..=73459",
            "73480..=73481",
            "73510..=73528",
        gaps: [
            "73460..=73479",
            "73482..=73509",
        ],
    }
[2022-07-12T14:38:12Z INFO  inx_chronicle::stardust_inx::syncer] Requesting unsynced milestone range 73482..73509.
[2022-07-12T14:38:15Z INFO  inx_chronicle::stardust_inx::syncer] Sync Data {
        completed: [
            "72201..=73501",
            "73510..=73529",
        ],
        gaps: [
            "73502..=73509",
        ],
    }
[2022-07-12T14:38:16Z INFO  inx_chronicle::stardust_inx::syncer] Successfully finished synchronization with node.
```