### PR TITLE
fix(db): 500 on hitting the balance/ endpoint (alternative)

### DIFF
--- a/bin/inx-chronicle/src/api/stardust/history/responses.rs
+++ b/bin/inx-chronicle/src/api/stardust/history/responses.rs
@@ -73,8 +73,8 @@ impl From<LedgerUpdateByMilestoneRecord> for LedgerUpdateByMilestoneResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BalanceResponse {
-    pub total_balance: u64,
-    pub sig_locked_balance: u64,
+    pub total_balance: String,
+    pub sig_locked_balance: String,
     pub ledger_index: MilestoneIndex,
 }
 

--- a/bin/inx-chronicle/src/api/stardust/history/routes.rs
+++ b/bin/inx-chronicle/src/api/stardust/history/routes.rs
@@ -125,8 +125,8 @@ async fn balance(database: Extension<MongoDb>, Path(address): Path<String>) -> A
         .ok_or(ApiError::NoResults)?;
 
     Ok(BalanceResponse {
-        total_balance: res.total_balance as u64,
-        sig_locked_balance: res.sig_locked_balance as u64,
+        total_balance: res.total_balance,
+        sig_locked_balance: res.sig_locked_balance,
         ledger_index: res.ledger_index,
     })
 }

--- a/bin/inx-chronicle/src/api/stardust/history/routes.rs
+++ b/bin/inx-chronicle/src/api/stardust/history/routes.rs
@@ -125,8 +125,8 @@ async fn balance(database: Extension<MongoDb>, Path(address): Path<String>) -> A
         .ok_or(ApiError::NoResults)?;
 
     Ok(BalanceResponse {
-        total_balance: res.total_balance,
-        sig_locked_balance: res.sig_locked_balance,
+        total_balance: res.total_balance as u64,
+        sig_locked_balance: res.sig_locked_balance as u64,
         ledger_index: res.ledger_index,
     })
 }

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -272,8 +272,8 @@ impl MongoDb {
 
         #[derive(Deserialize, Default)]
         struct Balances {
-            total_balance: Amount,
-            sig_locked_balance: Amount,
+            total_balance: Vec<Amount>,
+            sig_locked_balance: Vec<Amount>,
         }
 
         let ledger_index = self.get_ledger_index().await?;
@@ -298,7 +298,7 @@ impl MongoDb {
                                 { "$group" : {
                                     "_id": null,
                                     "amount": { "$sum": { "$toDouble": "$output.amount" } },
-                                }},
+                                } } ,
                             ],
                             // Sum only trivially unlockable output amounts (signature locked balance).
                             "sig_locked_balance": [
@@ -320,8 +320,8 @@ impl MongoDb {
                 .unwrap_or_default();
 
             Ok(Some(BalancesResult {
-                total_balance: balances.total_balance.amount as u64,
-                sig_locked_balance: balances.sig_locked_balance.amount as u64,
+                total_balance: balances.total_balance[0].amount as u64,
+                sig_locked_balance: balances.sig_locked_balance[0].amount as u64,
                 ledger_index,
             }))
         } else {

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -319,16 +319,22 @@ impl MongoDb {
                 .transpose()?
                 .unwrap_or_default();
 
+            // Note: this check means that the address wasn't found in this collection (bc otherwise there's an output
+            // with an actual amount).
             if balances.total_balance.is_empty() {
                 Ok(None)
             } else {
                 Ok(Some(BalancesResult {
                     total_balance: balances.total_balance[0].amount as u64,
-                    sig_locked_balance: balances.sig_locked_balance[0].amount as u64,
+                    // Note: for outputs that are only non-trivially unlockable we return a default of 0.
+                    sig_locked_balance: if balances.sig_locked_balance.is_empty() {
+                        0u64
+                    } else {
+                        balances.sig_locked_balance[0].amount as u64
+                    },
                     ledger_index,
                 }))
             }
-
         } else {
             Ok(None)
         }

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -296,7 +296,7 @@ impl MongoDb {
                             // Sum all output amounts (total balance).
                             "total_balance": [
                                 { "$group" : {
-                                    "_id": "null",
+                                    "_id": null,
                                     "amount": { "$sum": { "$toDouble": "$output.amount" } },
                                 }},
                             ],
@@ -304,7 +304,7 @@ impl MongoDb {
                             "sig_locked_balance": [
                                 { "$match": { "details.is_trivial_unlock": true } },
                                 { "$group" : {
-                                    "_id": "null",
+                                    "_id": null,
                                     "amount": { "$sum": { "$toDouble": "$output.amount" } },
                                 } },
                             ],

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -319,11 +319,16 @@ impl MongoDb {
                 .transpose()?
                 .unwrap_or_default();
 
-            Ok(Some(BalancesResult {
-                total_balance: balances.total_balance[0].amount as u64,
-                sig_locked_balance: balances.sig_locked_balance[0].amount as u64,
-                ledger_index,
-            }))
+            if balances.total_balance.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(BalancesResult {
+                    total_balance: balances.total_balance[0].amount as u64,
+                    sig_locked_balance: balances.sig_locked_balance[0].amount as u64,
+                    ledger_index,
+                }))
+            }
+
         } else {
             Ok(None)
         }

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -84,8 +84,8 @@ pub struct OutputWithMetadataResult {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[allow(missing_docs)]
 pub struct BalancesResult {
-    pub total_balance: f64,
-    pub sig_locked_balance: f64,
+    pub total_balance: String,
+    pub sig_locked_balance: String,
     pub ledger_index: MilestoneIndex,
 }
 
@@ -286,7 +286,7 @@ impl MongoDb {
                                 "total_balance": [
                                     { "$group" : {
                                         "_id": null,
-                                        "amount": { "$sum": { "$toDouble": "$output.amount" } },
+                                        "amount": { "$sum": { "$toDecimal": "$output.amount" } },
                                     } } ,
                                 ],
                                 // Sum only trivially unlockable output amounts (signature locked balance).
@@ -294,7 +294,7 @@ impl MongoDb {
                                     { "$match": { "details.is_trivial_unlock": true } },
                                     { "$group" : {
                                         "_id": null,
-                                        "amount": { "$sum": { "$toDouble": "$output.amount" } },
+                                        "amount": { "$sum": { "$toDecimal": "$output.amount" } },
                                     } },
                                 ],
                             } },
@@ -302,14 +302,16 @@ impl MongoDb {
                                 "total_balance": { 
                                     "$cond": { 
                                         "if": { "$gt": [ { "$size": "$total_balance.amount" }, 0 ] }, 
-                                        "then": { "$first": "$total_balance.amount"}, 
-                                        "else": { "$toDouble": 0 } },
+                                        "then": { "$toString": { "$first": "$total_balance.amount"} }, 
+                                        "else": { "$literal": "0" },
+                                    },
                                 },
                                 "sig_locked_balance": { 
                                     "$cond": { 
                                         "if": { "$gt": [ { "$size": "$sig_locked_balance.amount" }, 0 ] }, 
-                                        "then": { "$first": "$sig_locked_balance.amount"}, 
-                                        "else": { "$toDouble": 0 } },
+                                        "then": { "$toString": { "$first": "$sig_locked_balance.amount"} }, 
+                                        "else": { "$literal": "0" },
+                                    },
                                 },
                                 "ledger_index": { "$literal": ledger_index },
                             } },

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -299,8 +299,18 @@ impl MongoDb {
                                 ],
                             } },
                             doc! { "$project": {
-                                "total_balance": { "$first": "$total_balance.amount" },
-                                "sig_locked_balance": { "$first": "$sig_locked_balance.amount" },
+                                "total_balance": { 
+                                    "$cond": { 
+                                        "if": { "$gt": [ { "$size": "$total_balance.amount" }, 0 ] }, 
+                                        "then": { "$first": "$total_balance.amount"}, 
+                                        "else": { "$toDouble": 0 } },
+                                },
+                                "sig_locked_balance": { 
+                                    "$cond": { 
+                                        "if": { "$gt": [ { "$size": "$sig_locked_balance.amount" }, 0 ] }, 
+                                        "then": { "$first": "$sig_locked_balance.amount"}, 
+                                        "else": { "$toDouble": 0 } },
+                                },
                                 "ledger_index": { "$literal": ledger_index },
                             } },
                         ],


### PR DESCRIPTION
This is an alternative to #491 . The differences are:
* no intermediary helper structs to deserialize the db result
* returns a balance of `0` for unknown addresses