### PR TITLE
fix(api): move `children` endpoint to Explorer API

### DIFF
--- a/bin/inx-chronicle/src/api/stardust/core/responses.rs
+++ b/bin/inx-chronicle/src/api/stardust/core/responses.rs
@@ -17,16 +17,3 @@ pub struct InfoResponse {
 }
 
 impl_success_response!(InfoResponse);
-
-/// Response of GET /api/core/v2/blocks/{block_id}/children.
-/// Returns all children of a specific block.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BlockChildrenResponse {
-    pub block_id: String,
-    pub max_results: usize,
-    pub count: usize,
-    pub children: Vec<String>,
-}
-
-impl_success_response!(BlockChildrenResponse);

--- a/bin/inx-chronicle/src/api/stardust/explorer/responses.rs
+++ b/bin/inx-chronicle/src/api/stardust/explorer/responses.rs
@@ -79,3 +79,16 @@ pub struct BalanceResponse {
 }
 
 impl_success_response!(BalanceResponse);
+
+/// Response of GET /api/explorer/v2/blocks/{block_id}/children.
+/// Returns all children of a specific block.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockChildrenResponse {
+    pub block_id: String,
+    pub max_results: usize,
+    pub count: usize,
+    pub children: Vec<String>,
+}
+
+impl_success_response!(BlockChildrenResponse);

--- a/bin/inx-chronicle/src/api/stardust/explorer/routes.rs
+++ b/bin/inx-chronicle/src/api/stardust/explorer/routes.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use axum::{extract::Path, routing::get, Extension, Router};
 use chronicle::{
     db::MongoDb,
-    types::stardust::block::{Address, MilestoneId},
+    types::stardust::block::{Address, BlockId, MilestoneId},
 };
 use futures::{StreamExt, TryStreamExt};
 
@@ -15,17 +15,22 @@ use super::{
         LedgerUpdatesByAddressCursor, LedgerUpdatesByAddressPagination, LedgerUpdatesByMilestoneCursor,
         LedgerUpdatesByMilestonePagination,
     },
-    responses::{BalanceResponse, LedgerUpdatesByAddressResponse, LedgerUpdatesByMilestoneResponse},
+    responses::{
+        BalanceResponse, BlockChildrenResponse, LedgerUpdatesByAddressResponse, LedgerUpdatesByMilestoneResponse,
+    },
 };
-use crate::api::{ApiError, ApiResult};
+use crate::api::{extractors::Pagination, ApiError, ApiResult};
 
 pub fn routes() -> Router {
-    Router::new().route("/balance/:address", get(balance)).nest(
-        "/ledger/updates",
-        Router::new()
-            .route("/by-address/:address", get(ledger_updates_by_address))
-            .route("/by-milestone/:milestone_id", get(ledger_updates_by_milestone)),
-    )
+    Router::new()
+        .route("/balance/:address", get(balance))
+        .route("/blocks/:block_id/children", get(block_children))
+        .nest(
+            "/ledger/updates",
+            Router::new()
+                .route("/by-address/:address", get(ledger_updates_by_address))
+                .route("/by-milestone/:milestone_id", get(ledger_updates_by_milestone)),
+        )
 }
 
 async fn ledger_updates_by_address(
@@ -125,5 +130,29 @@ async fn balance(database: Extension<MongoDb>, Path(address): Path<String>) -> A
         total_balance: res.total_balance,
         sig_locked_balance: res.sig_locked_balance,
         ledger_index: res.ledger_index,
+    })
+}
+
+async fn block_children(
+    database: Extension<MongoDb>,
+    Path(block_id): Path<String>,
+    Pagination { page_size, page }: Pagination,
+) -> ApiResult<BlockChildrenResponse> {
+    let block_id = BlockId::from_str(&block_id).map_err(ApiError::bad_parse)?;
+    let mut block_children = database
+        .get_block_children(&block_id, page_size, page)
+        .await
+        .map_err(|_| ApiError::NoResults)?;
+
+    let mut children = Vec::new();
+    while let Some(block_id) = block_children.try_next().await? {
+        children.push(block_id.to_hex());
+    }
+
+    Ok(BlockChildrenResponse {
+        block_id: block_id.to_hex(),
+        max_results: page_size,
+        count: children.len(),
+        children,
     })
 }

--- a/docs/api-explorer.yml
+++ b/docs/api-explorer.yml
@@ -14,10 +14,12 @@ externalDocs:
 servers:
   - url: "http://127.0.0.1:8000"
 tags:
-  - name: ledger
-    description: Everything about the ledger.
   - name: balance
     description: Everything about balances.
+  - name: blocks
+    description: Everything about blocks.
+  - name: ledger
+    description: Everything about the ledger.
 paths:
   /api/explorer/v2/balance/{address}:
     get:
@@ -38,6 +40,34 @@ paths:
               examples:
                 default:
                   $ref: "#/components/examples/balance-example"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NoResults"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/explorer/v2/blocks/{blockId}/children:
+    get:
+      tags:
+        - blocks
+      summary: Returns the children of a block.
+      description: >-
+        Returns the children of a given block in the Tangle.
+      parameters:
+        - in: path
+          name: blockId
+          schema:
+            type: string
+          example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
+          required: true
+          description: Identifier of the block.
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BlockChildrenResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
@@ -117,6 +147,23 @@ components:
         ledgerIndex:
           type: integer
           description: The ledger index for which the balance calculation was performed.
+    BlockChildrenResponse:
+      description: Returns the children of a given block.
+      properties:
+        blockId:
+          type: string
+          description: The block id of the parent.
+        maxResults:
+          type: integer
+          description: The maximum number of results.
+        count:
+          type: integer
+          description: The total number of children.
+        children:
+          type: array
+          description: A list of block ids.
+          items:
+            type: string
     LedgerUpdatesByMilestoneResponse:
       description: A list of ledger updates associated with a milestone.
       properties:


### PR DESCRIPTION
Closes: #321.