### PR TITLE
fix(api): remove `u32` from `transaction-included-block` endpoint

### DIFF
--- a/src/bin/inx-chronicle/api/stardust/core/routes.rs
+++ b/src/bin/inx-chronicle/api/stardust/core/routes.rs
@@ -266,7 +266,6 @@ async fn output_metadata(
 
 async fn transaction_included_block(
     database: Extension<MongoDb>,
-    Path(_): Path<u32>,
     Path(transaction_id): Path<String>,
 ) -> ApiResult<BlockResponse> {
     let transaction_id = TransactionId::from_str(&transaction_id).map_err(ApiError::bad_parse)?;


### PR DESCRIPTION
Closes #592.