### PR TITLE
feat(db): separate database collections into individual types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ console-subscriber = { version = "0.1", default-features = false, optional = tru
 
 [dev-dependencies]
 packable = { version = "0.5", default-features = false }
+rand = { version = "0.8", default-features = false, features = [ "std" ] }
 
 [features]
 default = [ 

--- a/src/bin/inx-chronicle/api/routes.rs
+++ b/src/bin/inx-chronicle/api/routes.rs
@@ -8,7 +8,10 @@ use axum::{
     routing::{get, post},
     Extension, Json, Router,
 };
-use chronicle::{db::MongoDb, types::stardust::milestone::MilestoneTimestamp};
+use chronicle::{
+    db::{collections::MilestoneCollection, MongoDb},
+    types::stardust::milestone::MilestoneTimestamp,
+};
 use hyper::StatusCode;
 use serde::Deserialize;
 use time::{Duration, OffsetDateTime};
@@ -70,7 +73,11 @@ fn is_new_enough(timestamp: MilestoneTimestamp) -> bool {
 pub async fn is_healthy(database: &MongoDb) -> Result<bool, ApiError> {
     #[cfg(feature = "stardust")]
     {
-        let newest = match database.get_newest_milestone().await? {
+        let newest = match database
+            .collection::<MilestoneCollection>()
+            .get_newest_milestone()
+            .await?
+        {
             Some(last) => last,
             None => return Ok(false),
         };

--- a/src/bin/inx-chronicle/api/stardust/analytics/routes.rs
+++ b/src/bin/inx-chronicle/api/stardust/analytics/routes.rs
@@ -5,7 +5,7 @@ use axum::{routing::get, Extension, Router};
 use bee_api_types_stardust::responses::RentStructureResponse;
 use chronicle::{
     db::{
-        collections::{OutputKind, PayloadKind},
+        collections::{BlockCollection, OutputCollection, OutputKind, PayloadKind, ProtocolUpdateCollection},
         MongoDb,
     },
     types::stardust::block::{
@@ -69,7 +69,10 @@ async fn address_activity_analytics(
     database: Extension<MongoDb>,
     MilestoneRange { start_index, end_index }: MilestoneRange,
 ) -> ApiResult<AddressAnalyticsResponse> {
-    let res = database.get_address_analytics(start_index, end_index).await?;
+    let res = database
+        .collection::<OutputCollection>()
+        .get_address_analytics(start_index, end_index)
+        .await?;
 
     Ok(AddressAnalyticsResponse {
         total_active_addresses: res.total_active_addresses.to_string(),
@@ -82,7 +85,10 @@ async fn block_activity_analytics<B: PayloadKind>(
     database: Extension<MongoDb>,
     MilestoneRange { start_index, end_index }: MilestoneRange,
 ) -> ApiResult<BlockAnalyticsResponse> {
-    let res = database.get_block_analytics::<B>(start_index, end_index).await?;
+    let res = database
+        .collection::<BlockCollection>()
+        .get_block_analytics::<B>(start_index, end_index)
+        .await?;
 
     Ok(BlockAnalyticsResponse {
         count: res.count.to_string(),
@@ -93,7 +99,10 @@ async fn output_activity_analytics<O: OutputKind>(
     database: Extension<MongoDb>,
     MilestoneRange { start_index, end_index }: MilestoneRange,
 ) -> ApiResult<OutputAnalyticsResponse> {
-    let res = database.get_output_analytics::<O>(start_index, end_index).await?;
+    let res = database
+        .collection::<OutputCollection>()
+        .get_output_analytics::<O>(start_index, end_index)
+        .await?;
 
     Ok(OutputAnalyticsResponse {
         count: res.count.to_string(),
@@ -106,6 +115,7 @@ async fn unspent_output_ledger_analytics<O: OutputKind>(
     LedgerIndex { ledger_index }: LedgerIndex,
 ) -> ApiResult<OutputAnalyticsResponse> {
     let res = database
+        .collection::<OutputCollection>()
         .get_unspent_output_analytics::<O>(ledger_index)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -121,6 +131,7 @@ async fn storage_deposit_ledger_analytics(
     LedgerIndex { ledger_index }: LedgerIndex,
 ) -> ApiResult<StorageDepositAnalyticsResponse> {
     let res = database
+        .collection::<OutputCollection>()
         .get_storage_deposit_analytics(ledger_index)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -145,7 +156,10 @@ async fn nft_activity_analytics(
     database: Extension<MongoDb>,
     MilestoneRange { start_index, end_index }: MilestoneRange,
 ) -> ApiResult<OutputDiffAnalyticsResponse> {
-    let res = database.get_nft_output_analytics(start_index, end_index).await?;
+    let res = database
+        .collection::<OutputCollection>()
+        .get_nft_output_analytics(start_index, end_index)
+        .await?;
 
     Ok(OutputDiffAnalyticsResponse {
         created_count: res.created_count.to_string(),
@@ -158,7 +172,10 @@ async fn native_token_activity_analytics(
     database: Extension<MongoDb>,
     MilestoneRange { start_index, end_index }: MilestoneRange,
 ) -> ApiResult<OutputDiffAnalyticsResponse> {
-    let res = database.get_foundry_output_analytics(start_index, end_index).await?;
+    let res = database
+        .collection::<OutputCollection>()
+        .get_foundry_output_analytics(start_index, end_index)
+        .await?;
 
     Ok(OutputDiffAnalyticsResponse {
         created_count: res.created_count.to_string(),
@@ -172,11 +189,13 @@ async fn richest_addresses_ledger_analytics(
     RichestAddressesQuery { top, ledger_index }: RichestAddressesQuery,
 ) -> ApiResult<RichestAddressesResponse> {
     let res = database
+        .collection::<OutputCollection>()
         .get_richest_addresses(ledger_index, top)
         .await?
         .ok_or(ApiError::NoResults)?;
 
     let hrp = database
+        .collection::<ProtocolUpdateCollection>()
         .get_protocol_parameters_for_ledger_index(res.ledger_index)
         .await?
         .ok_or(InternalApiError::CorruptState("no protocol parameters"))?
@@ -201,6 +220,7 @@ async fn token_distribution_ledger_analytics(
     LedgerIndex { ledger_index }: LedgerIndex,
 ) -> ApiResult<TokenDistributionResponse> {
     let res = database
+        .collection::<OutputCollection>()
         .get_token_distribution(ledger_index)
         .await?
         .ok_or(ApiError::NoResults)?;

--- a/src/bin/inx-chronicle/api/stardust/core/routes.rs
+++ b/src/bin/inx-chronicle/api/stardust/core/routes.rs
@@ -25,7 +25,10 @@ use bee_block_stardust::{
 };
 use chronicle::{
     db::{
-        collections::{OutputMetadataResult, OutputWithMetadataResult, UtxoChangesResult},
+        collections::{
+            BlockCollection, MilestoneCollection, OutputCollection, OutputMetadataResult, OutputWithMetadataResult,
+            ProtocolUpdateCollection, TreasuryCollection, UtxoChangesResult,
+        },
         MongoDb,
     },
     types::{
@@ -101,6 +104,7 @@ pub fn routes() -> Router {
 
 pub async fn info(database: Extension<MongoDb>) -> ApiResult<InfoResponse> {
     let protocol = database
+        .collection::<ProtocolUpdateCollection>()
         .get_latest_protocol_parameters()
         .await?
         .ok_or(ApiError::Internal(InternalApiError::CorruptState(
@@ -113,26 +117,27 @@ pub async fn info(database: Extension<MongoDb>) -> ApiResult<InfoResponse> {
         false
     });
 
-    let newest_milestone =
-        database
-            .get_newest_milestone()
-            .await?
-            .ok_or(ApiError::Internal(InternalApiError::CorruptState(
-                "no milestone in the database",
-            )))?;
-    let oldest_milestone =
-        database
-            .get_oldest_milestone()
-            .await?
-            .ok_or(ApiError::Internal(InternalApiError::CorruptState(
-                "no milestone in the database",
-            )))?;
+    let newest_milestone = database
+        .collection::<MilestoneCollection>()
+        .get_newest_milestone()
+        .await?
+        .ok_or(ApiError::Internal(InternalApiError::CorruptState(
+            "no milestone in the database",
+        )))?;
+    let oldest_milestone = database
+        .collection::<MilestoneCollection>()
+        .get_oldest_milestone()
+        .await?
+        .ok_or(ApiError::Internal(InternalApiError::CorruptState(
+            "no milestone in the database",
+        )))?;
 
     let latest_milestone = LatestMilestoneResponse {
         index: newest_milestone.milestone_index.0,
         timestamp: newest_milestone.milestone_timestamp.0,
         milestone_id: bee_block_stardust::payload::milestone::MilestoneId::from(
             database
+                .collection::<MilestoneCollection>()
                 .get_milestone_id(newest_milestone.milestone_index)
                 .await?
                 .ok_or(ApiError::Internal(InternalApiError::CorruptState(
@@ -183,12 +188,20 @@ async fn block(
     if let Some(value) = headers.get(axum::http::header::ACCEPT) {
         if value.eq(&*BYTE_CONTENT_HEADER) {
             return Ok(BlockResponse::Raw(
-                database.get_block_raw(&block_id).await?.ok_or(ApiError::NoResults)?,
+                database
+                    .collection::<BlockCollection>()
+                    .get_block_raw(&block_id)
+                    .await?
+                    .ok_or(ApiError::NoResults)?,
             ));
         }
     }
 
-    let block = database.get_block(&block_id).await?.ok_or(ApiError::NoResults)?;
+    let block = database
+        .collection::<BlockCollection>()
+        .get_block(&block_id)
+        .await?
+        .ok_or(ApiError::NoResults)?;
     Ok(BlockResponse::Json(BlockDto::try_from(block)?))
 }
 
@@ -198,6 +211,7 @@ async fn block_metadata(
 ) -> ApiResult<BlockMetadataResponse> {
     let block_id = BlockId::from_str(&block_id_str).map_err(ApiError::bad_parse)?;
     let metadata = database
+        .collection::<BlockCollection>()
         .get_block_metadata(&block_id)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -243,6 +257,7 @@ fn create_output_metadata_response(metadata: OutputMetadataResult) -> OutputMeta
 async fn output(database: Extension<MongoDb>, Path(output_id): Path<String>) -> ApiResult<OutputResponse> {
     let output_id = OutputId::from_str(&output_id).map_err(ApiError::bad_parse)?;
     let OutputWithMetadataResult { output, metadata } = database
+        .collection::<OutputCollection>()
         .get_output_with_metadata(&output_id)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -261,6 +276,7 @@ async fn output_metadata(
 ) -> ApiResult<OutputMetadataResponse> {
     let output_id = OutputId::from_str(&output_id).map_err(ApiError::bad_parse)?;
     let metadata = database
+        .collection::<OutputCollection>()
         .get_output_metadata(&output_id)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -274,6 +290,7 @@ async fn transaction_included_block(
 ) -> ApiResult<BlockResponse> {
     let transaction_id = TransactionId::from_str(&transaction_id).map_err(ApiError::bad_parse)?;
     let block = database
+        .collection::<BlockCollection>()
         .get_block_for_transaction(&transaction_id)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -282,7 +299,10 @@ async fn transaction_included_block(
 }
 
 async fn receipts(database: Extension<MongoDb>) -> ApiResult<ReceiptsResponse> {
-    let mut receipts_at = database.stream_all_receipts().await?;
+    let mut receipts_at = database
+        .collection::<MilestoneCollection>()
+        .stream_all_receipts()
+        .await?;
     let mut receipts = Vec::new();
     while let Some((receipt, at)) = receipts_at.try_next().await? {
         let receipt: &bee_block_stardust::payload::milestone::MilestoneOption = &receipt.try_into()?;
@@ -301,7 +321,10 @@ async fn receipts(database: Extension<MongoDb>) -> ApiResult<ReceiptsResponse> {
 }
 
 async fn receipts_migrated_at(database: Extension<MongoDb>, Path(index): Path<u32>) -> ApiResult<ReceiptsResponse> {
-    let mut receipts_at = database.stream_receipts_migrated_at(index.into()).await?;
+    let mut receipts_at = database
+        .collection::<MilestoneCollection>()
+        .stream_receipts_migrated_at(index.into())
+        .await?;
     let mut receipts = Vec::new();
     while let Some((receipt, at)) = receipts_at.try_next().await? {
         let receipt: &bee_block_stardust::payload::milestone::MilestoneOption = &receipt.try_into()?;
@@ -321,6 +344,7 @@ async fn receipts_migrated_at(database: Extension<MongoDb>, Path(index): Path<u3
 
 async fn treasury(database: Extension<MongoDb>) -> ApiResult<TreasuryResponse> {
     database
+        .collection::<TreasuryCollection>()
         .get_latest_treasury()
         .await?
         .ok_or(ApiError::NoResults)
@@ -337,6 +361,7 @@ async fn milestone(
 ) -> ApiResult<MilestoneResponse> {
     let milestone_id = MilestoneId::from_str(&milestone_id).map_err(ApiError::bad_parse)?;
     let milestone_payload = database
+        .collection::<MilestoneCollection>()
         .get_milestone_payload_by_id(&milestone_id)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -359,6 +384,7 @@ async fn milestone_by_index(
     headers: HeaderMap,
 ) -> ApiResult<MilestoneResponse> {
     let milestone_payload = database
+        .collection::<MilestoneCollection>()
         .get_milestone_payload(index)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -381,6 +407,7 @@ async fn utxo_changes(
 ) -> ApiResult<UtxoChangesResponse> {
     let milestone_id = MilestoneId::from_str(&milestone_id).map_err(ApiError::bad_parse)?;
     let milestone_index = database
+        .collection::<MilestoneCollection>()
         .get_milestone_payload_by_id(&milestone_id)
         .await?
         .ok_or(ApiError::NoResults)?
@@ -401,6 +428,7 @@ async fn collect_utxo_changes(database: &MongoDb, milestone_index: MilestoneInde
         created_outputs,
         consumed_outputs,
     } = database
+        .collection::<OutputCollection>()
         .get_utxo_changes(milestone_index)
         .await?
         .ok_or(ApiError::NoResults)?;

--- a/src/bin/inx-chronicle/api/stardust/indexer/routes.rs
+++ b/src/bin/inx-chronicle/api/stardust/indexer/routes.rs
@@ -6,7 +6,9 @@ use std::str::FromStr;
 use axum::{extract::Path, routing::get, Extension, Router};
 use chronicle::{
     db::{
-        collections::{AliasOutputsQuery, BasicOutputsQuery, FoundryOutputsQuery, IndexedId, NftOutputsQuery},
+        collections::{
+            AliasOutputsQuery, BasicOutputsQuery, FoundryOutputsQuery, IndexedId, NftOutputsQuery, OutputCollection,
+        },
         MongoDb,
     },
     types::stardust::block::output::{AliasId, FoundryId, NftId},
@@ -52,6 +54,7 @@ where
 {
     let id = ID::from_str(&id).map_err(ApiError::bad_parse)?;
     let res = database
+        .collection::<OutputCollection>()
         .get_indexed_output_by_id(id)
         .await?
         .ok_or(ApiError::NoResults)?;
@@ -76,6 +79,7 @@ where
     bson::Document: From<Q>,
 {
     let res = database
+        .collection::<OutputCollection>()
         .get_indexed_outputs(
             query,
             // Get one extra record so that we can create the cursor.

--- a/src/bin/inx-chronicle/launcher.rs
+++ b/src/bin/inx-chronicle/launcher.rs
@@ -4,7 +4,10 @@
 use async_trait::async_trait;
 use bytesize::ByteSize;
 use chronicle::{
-    db::MongoDb,
+    db::{
+        collections::{BlockCollection, LedgerUpdateCollection, MilestoneCollection, OutputCollection},
+        MongoDb,
+    },
     runtime::{Actor, ActorContext, ErrorLevel, RuntimeError},
 };
 use clap::Parser;
@@ -77,10 +80,10 @@ impl Actor for Launcher {
 
         #[cfg(feature = "stardust")]
         {
-            db.create_output_indexes().await?;
-            db.create_block_indexes().await?;
-            db.create_ledger_update_indexes().await?;
-            db.create_milestone_indexes().await?;
+            db.collection::<OutputCollection>().create_indexes().await?;
+            db.collection::<BlockCollection>().create_indexes().await?;
+            db.collection::<LedgerUpdateCollection>().create_indexes().await?;
+            db.collection::<MilestoneCollection>().create_indexes().await?;
         }
 
         #[cfg(all(feature = "inx", feature = "stardust"))]

--- a/src/bin/inx-chronicle/stardust_inx/chunks.rs
+++ b/src/bin/inx-chronicle/stardust_inx/chunks.rs
@@ -1,0 +1,345 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+
+pub trait ChunksExt: Iterator {
+    fn chunks(self, size: usize) -> IntoChunks<Self>
+    where
+        Self: Sized,
+    {
+        IntoChunks {
+            inner: Arc::new(Mutex::new(GroupInner {
+                key: ChunkIndex::new(size),
+                iter: self,
+                current_key: None,
+                current_elt: None,
+                done: false,
+                top_group: 0,
+                oldest_buffered_group: 0,
+                bottom_group: 0,
+                buffer: Vec::new(),
+                dropped_group: !0,
+            })),
+            index: AtomicUsize::new(0),
+        }
+    }
+}
+impl<T: Iterator> ChunksExt for T {}
+
+pub struct IntoChunks<I: Iterator> {
+    inner: Arc<Mutex<GroupInner<usize, I, ChunkIndex>>>,
+    index: AtomicUsize,
+}
+
+impl<I: Iterator> IntoChunks<I> {
+    /// `client`: Index of chunk that requests next element
+    fn step(&self, client: usize) -> Option<I::Item> {
+        self.inner.lock().unwrap().step(client)
+    }
+
+    /// `client`: Index of chunk
+    fn drop_group(&self, client: usize) {
+        self.inner.lock().unwrap().drop_group(client)
+    }
+}
+
+impl<'a, I: Iterator> IntoIterator for &'a IntoChunks<I> {
+    type Item = Chunk<'a, I>;
+    type IntoIter = Chunks<'a, I>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Chunks { parent: self }
+    }
+}
+
+pub struct Chunks<'a, I: Iterator> {
+    parent: &'a IntoChunks<I>,
+}
+
+impl<'a, I: Iterator> Iterator for Chunks<'a, I> {
+    type Item = Chunk<'a, I>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.parent.index.fetch_add(1, Ordering::Relaxed);
+        let inner = &mut *self.parent.inner.lock().unwrap();
+        inner.step(index).map(|elt| Chunk {
+            parent: self.parent,
+            index,
+            first: Some(elt),
+        })
+    }
+}
+
+pub struct Chunk<'a, I: Iterator> {
+    parent: &'a IntoChunks<I>,
+    index: usize,
+    first: Option<I::Item>,
+}
+
+impl<'a, I: Iterator> Drop for Chunk<'a, I> {
+    fn drop(&mut self) {
+        self.parent.drop_group(self.index);
+    }
+}
+
+impl<'a, I: Iterator> Iterator for Chunk<'a, I> {
+    type Item = I::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let elt @ Some(..) = self.first.take() {
+            return elt;
+        }
+        self.parent.step(self.index)
+    }
+}
+
+struct GroupInner<K, I, F>
+where
+    I: Iterator,
+{
+    key: F,
+    iter: I,
+    current_key: Option<K>,
+    current_elt: Option<I::Item>,
+    /// flag set if iterator is exhausted
+    done: bool,
+    /// Index of group we are currently buffering or visiting
+    top_group: usize,
+    /// Least index for which we still have elements buffered
+    oldest_buffered_group: usize,
+    /// Group index for `buffer[0]` -- the slots
+    /// bottom_group..oldest_buffered_group are unused and will be erased when
+    /// that range is large enough.
+    bottom_group: usize,
+    /// Buffered groups, from `bottom_group` (index 0) to `top_group`.
+    buffer: Vec<std::vec::IntoIter<I::Item>>,
+    /// index of last group iter that was dropped, usize::MAX == none
+    dropped_group: usize,
+}
+
+impl<K, I, F> GroupInner<K, I, F>
+where
+    I: Iterator,
+    F: for<'a> KeyFunction<&'a I::Item, Key = K>,
+    K: PartialEq,
+{
+    /// `client`: Index of group that requests next element
+    #[inline(always)]
+    fn step(&mut self, client: usize) -> Option<I::Item> {
+        // println!("client={}, bottom_group={}, oldest_buffered_group={}, top_group={}, buffers=[{}]",
+        // client, self.bottom_group, self.oldest_buffered_group,
+        // self.top_group,
+        // self.buffer.iter().map(|elt| elt.len()).format(", "));
+        if client < self.oldest_buffered_group {
+            None
+        } else if client < self.top_group
+            || (client == self.top_group && self.buffer.len() > self.top_group - self.bottom_group)
+        {
+            self.lookup_buffer(client)
+        } else if self.done {
+            None
+        } else if self.top_group == client {
+            self.step_current()
+        } else {
+            self.step_buffering(client)
+        }
+    }
+
+    #[inline(never)]
+    fn lookup_buffer(&mut self, client: usize) -> Option<I::Item> {
+        // if `bufidx` doesn't exist in self.buffer, it might be empty
+        let bufidx = client - self.bottom_group;
+        if client < self.oldest_buffered_group {
+            return None;
+        }
+        let elt = self.buffer.get_mut(bufidx).and_then(|queue| queue.next());
+        if elt.is_none() && client == self.oldest_buffered_group {
+            // FIXME: VecDeque is unfortunately not zero allocation when empty,
+            // so we do this job manually.
+            // `bottom_group..oldest_buffered_group` is unused, and if it's large enough, erase it.
+            self.oldest_buffered_group += 1;
+            // skip forward further empty queues too
+            while self
+                .buffer
+                .get(self.oldest_buffered_group - self.bottom_group)
+                .map_or(false, |buf| buf.len() == 0)
+            {
+                self.oldest_buffered_group += 1;
+            }
+
+            let nclear = self.oldest_buffered_group - self.bottom_group;
+            if nclear > 0 && nclear >= self.buffer.len() / 2 {
+                let mut i = 0;
+                self.buffer.retain(|buf| {
+                    i += 1;
+                    debug_assert!(buf.len() == 0 || i > nclear);
+                    i > nclear
+                });
+                self.bottom_group = self.oldest_buffered_group;
+            }
+        }
+        elt
+    }
+
+    /// Take the next element from the iterator, and set the done
+    /// flag if exhausted. Must not be called after done.
+    #[inline(always)]
+    fn next_element(&mut self) -> Option<I::Item> {
+        debug_assert!(!self.done);
+        match self.iter.next() {
+            None => {
+                self.done = true;
+                None
+            }
+            otherwise => otherwise,
+        }
+    }
+
+    #[inline(never)]
+    fn step_buffering(&mut self, client: usize) -> Option<I::Item> {
+        // requested a later group -- walk through the current group up to
+        // the requested group index, and buffer the elements (unless
+        // the group is marked as dropped).
+        // Because the `Groups` iterator is always the first to request
+        // each group index, client is the next index efter top_group.
+        debug_assert!(self.top_group + 1 == client);
+        let mut group = Vec::new();
+
+        if let Some(elt) = self.current_elt.take() {
+            if self.top_group != self.dropped_group {
+                group.push(elt);
+            }
+        }
+        let mut first_elt = None; // first element of the next group
+
+        while let Some(elt) = self.next_element() {
+            let key = self.key.call_mut(&elt);
+            match self.current_key.take() {
+                None => {}
+                Some(old_key) => {
+                    if old_key != key {
+                        self.current_key = Some(key);
+                        first_elt = Some(elt);
+                        break;
+                    }
+                }
+            }
+            self.current_key = Some(key);
+            if self.top_group != self.dropped_group {
+                group.push(elt);
+            }
+        }
+
+        if self.top_group != self.dropped_group {
+            self.push_next_group(group);
+        }
+        if first_elt.is_some() {
+            self.top_group += 1;
+            debug_assert!(self.top_group == client);
+        }
+        first_elt
+    }
+
+    fn push_next_group(&mut self, group: Vec<I::Item>) {
+        // When we add a new buffered group, fill up slots between oldest_buffered_group and top_group
+        while self.top_group - self.bottom_group > self.buffer.len() {
+            if self.buffer.is_empty() {
+                self.bottom_group += 1;
+                self.oldest_buffered_group += 1;
+            } else {
+                self.buffer.push(Vec::new().into_iter());
+            }
+        }
+        self.buffer.push(group.into_iter());
+        debug_assert!(self.top_group + 1 - self.bottom_group == self.buffer.len());
+    }
+
+    /// This is the immediate case, where we use no buffering
+    #[inline]
+    fn step_current(&mut self) -> Option<I::Item> {
+        debug_assert!(!self.done);
+        if let elt @ Some(..) = self.current_elt.take() {
+            return elt;
+        }
+        match self.next_element() {
+            None => None,
+            Some(elt) => {
+                let key = self.key.call_mut(&elt);
+                match self.current_key.take() {
+                    None => {}
+                    Some(old_key) => {
+                        if old_key != key {
+                            self.current_key = Some(key);
+                            self.current_elt = Some(elt);
+                            self.top_group += 1;
+                            return None;
+                        }
+                    }
+                }
+                self.current_key = Some(key);
+                Some(elt)
+            }
+        }
+    }
+}
+
+impl<K, I, F> GroupInner<K, I, F>
+where
+    I: Iterator,
+{
+    /// Called when a group is dropped
+    fn drop_group(&mut self, client: usize) {
+        // It's only useful to track the maximal index
+        if self.dropped_group == !0 || client > self.dropped_group {
+            self.dropped_group = client;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ChunkIndex {
+    size: usize,
+    index: usize,
+    key: usize,
+}
+
+impl ChunkIndex {
+    #[inline(always)]
+    fn new(size: usize) -> Self {
+        ChunkIndex { size, index: 0, key: 0 }
+    }
+}
+
+trait KeyFunction<A> {
+    type Key;
+    fn call_mut(&mut self, arg: A) -> Self::Key;
+}
+
+impl<A, K, F: ?Sized> KeyFunction<A> for F
+where
+    F: FnMut(A) -> K,
+{
+    type Key = K;
+    #[inline]
+    fn call_mut(&mut self, arg: A) -> Self::Key {
+        (*self)(arg)
+    }
+}
+
+impl<A> KeyFunction<A> for ChunkIndex {
+    type Key = usize;
+    #[inline(always)]
+    fn call_mut(&mut self, _arg: A) -> Self::Key {
+        if self.index == self.size {
+            self.key += 1;
+            self.index = 0;
+        }
+        self.index += 1;
+        self.key
+    }
+}

--- a/src/bin/inx-chronicle/stardust_inx/chunks.rs
+++ b/src/bin/inx-chronicle/stardust_inx/chunks.rs
@@ -378,7 +378,7 @@ mod test {
             }
             // Shuffle up the tasks, because order shouldn't matter to the iterator
             tasks.shuffle(&mut rng);
-            assert!(futures::future::join_all(tasks).await.len() > 0);
+            assert!(!futures::future::join_all(tasks).await.is_empty());
         }
     }
 
@@ -387,8 +387,7 @@ mod test {
     fn test_chunks_zero_len() {
         // Shh...
         std::panic::set_hook(Box::new(|_| {}));
-        let data = (0..25).collect::<Vec<_>>();
-        for chunk in &data.into_iter().chunks(0) {
+        for chunk in &(0..25).chunks(0) {
             let _ = chunk.collect::<Vec<_>>();
         }
     }

--- a/src/bin/inx-chronicle/stardust_inx/mod.rs
+++ b/src/bin/inx-chronicle/stardust_inx/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+mod chunks;
 mod config;
 mod error;
 mod stream;
@@ -8,20 +9,29 @@ mod stream;
 use async_trait::async_trait;
 use bee_inx::client::Inx;
 use chronicle::{
-    db::{collections::INSERT_BATCH_SIZE, MongoDb},
+    db::{
+        collections::{
+            BlockCollection, LedgerUpdateCollection, MilestoneCollection, OutputCollection, ProtocolUpdateCollection,
+            TreasuryCollection,
+        },
+        MongoDb,
+    },
     runtime::{Actor, ActorContext, HandleEvent},
     types::{
-        ledger::{LedgerOutput, LedgerSpent, MilestoneIndexTimestamp},
+        ledger::{BlockMetadata, LedgerInclusionState, LedgerOutput, LedgerSpent, MilestoneIndexTimestamp},
+        stardust::block::{Block, BlockId, Payload},
         tangle::{MilestoneIndex, ProtocolParameters},
     },
 };
-pub use config::InxConfig;
-pub use error::InxError;
 use futures::{StreamExt, TryStreamExt};
 use tokio::try_join;
 use tracing::{debug, info, instrument, trace_span, warn, Instrument};
 
-use self::stream::LedgerUpdateStream;
+use self::{chunks::ChunksExt, stream::LedgerUpdateStream};
+pub use self::{config::InxConfig, error::InxError};
+
+/// Batch size for insert operations.
+pub const INSERT_BATCH_SIZE: usize = 10000;
 
 pub struct InxWorker {
     db: MongoDb,
@@ -88,7 +98,11 @@ impl Actor for InxWorker {
         let start_index = if let Some(MilestoneIndexTimestamp {
             milestone_index: latest_milestone,
             ..
-        }) = self.db.get_newest_milestone().await?
+        }) = self
+            .db
+            .collection::<MilestoneCollection>()
+            .get_newest_milestone()
+            .await?
         {
             if node_status.tangle_pruning_index > latest_milestone.0 {
                 return Err(InxError::SyncMilestoneGap {
@@ -117,7 +131,12 @@ impl Actor for InxWorker {
 
         debug!("Connected to network `{}`.", protocol_parameters.network_name);
 
-        if let Some(latest) = self.db.get_latest_protocol_parameters().await? {
+        if let Some(latest) = self
+            .db
+            .collection::<ProtocolUpdateCollection>()
+            .get_latest_protocol_parameters()
+            .await?
+        {
             if latest.parameters.network_name != protocol_parameters.network_name {
                 return Err(InxError::NetworkChanged(
                     latest.parameters.network_name,
@@ -128,6 +147,7 @@ impl Actor for InxWorker {
             if latest.parameters != protocol_parameters {
                 debug!("Updating protocol parameters.");
                 self.db
+                    .collection::<ProtocolUpdateCollection>()
                     .insert_protocol_parameters(start_index, protocol_parameters)
                     .await?;
             }
@@ -176,6 +196,7 @@ impl Actor for InxWorker {
             );
 
             self.db
+                .collection::<ProtocolUpdateCollection>()
                 .insert_protocol_parameters(start_index, protocol_parameters)
                 .await?;
         }
@@ -252,19 +273,43 @@ impl HandleEvent<Result<LedgerUpdateRecord, InxError>> for InxWorker {
 
 #[instrument(skip_all, fields(num = outputs.len()), level = "trace")]
 async fn insert_unspent_outputs(db: &MongoDb, outputs: Vec<LedgerOutput>) -> Result<(), InxError> {
-    try_join!(
-        db.insert_unspent_outputs(outputs.iter()),
-        db.insert_unspent_ledger_updates(outputs.iter())
-    )?;
+    let output_collection = db.collection::<OutputCollection>();
+    let ledger_collection = db.collection::<LedgerUpdateCollection>();
+    try_join! {
+        async {
+            for batch in &outputs.iter().chunks(INSERT_BATCH_SIZE) {
+                output_collection.insert_unspent_outputs(batch).await?;
+            }
+            Result::<_, InxError>::Ok(())
+        },
+        async {
+            for batch in &outputs.iter().chunks(INSERT_BATCH_SIZE) {
+                ledger_collection.insert_unspent_ledger_updates(batch).await?;
+            }
+            Ok(())
+        }
+    }?;
     Ok(())
 }
 
 #[instrument(skip_all, fields(num = outputs.len()), level = "trace")]
 async fn update_spent_outputs(db: &MongoDb, outputs: Vec<LedgerSpent>) -> Result<(), InxError> {
-    try_join!(
-        db.update_spent_outputs(outputs.iter()),
-        db.insert_spent_ledger_updates(outputs.iter()),
-    )?;
+    let output_collection = db.collection::<OutputCollection>();
+    let ledger_collection = db.collection::<LedgerUpdateCollection>();
+    try_join! {
+        async {
+            for batch in &outputs.iter().chunks(INSERT_BATCH_SIZE) {
+                output_collection.update_spent_outputs(batch).await?;
+            }
+            Result::<_, InxError>::Ok(())
+        },
+        async {
+            for batch in &outputs.iter().chunks(INSERT_BATCH_SIZE) {
+                ledger_collection.insert_spent_ledger_updates(batch).await?;
+            }
+            Ok(())
+        }
+    }?;
     Ok(())
 }
 
@@ -276,7 +321,8 @@ async fn handle_protocol_params(db: &MongoDb, inx: &mut Inx, milestone_index: Mi
         .inner()?
         .into();
 
-    db.update_latest_protocol_parameters(milestone_index, parameters)
+    db.collection::<ProtocolUpdateCollection>()
+        .update_latest_protocol_parameters(milestone_index, parameters)
         .await?;
 
     Ok(())
@@ -300,7 +346,8 @@ async fn handle_milestone(db: &MongoDb, inx: &mut Inx, milestone_index: Mileston
             .ok_or(InxError::MissingMilestoneInfo(milestone_index))?,
     );
 
-    db.insert_milestone(milestone_id, milestone_index, milestone_timestamp, payload)
+    db.collection::<MilestoneCollection>()
+        .insert_milestone(milestone_id, milestone_index, milestone_timestamp, payload)
         .await?;
 
     metrics::gauge!(METRIC_MILESTONE_INDEX, milestone_index.0 as f64);
@@ -326,7 +373,33 @@ async fn handle_cone_stream(db: &MongoDb, inx: &mut Inx, milestone_index: Milest
         .try_collect::<Vec<_>>()
         .await?;
 
-    db.insert_blocks_with_metadata(blocks_with_metadata).await?;
+    let payloads = blocks_with_metadata
+        .iter()
+        .filter_map(|(_, block, _, metadata): &(BlockId, Block, Vec<u8>, BlockMetadata)| {
+            if metadata.inclusion_state == LedgerInclusionState::Included {
+                if let Some(Payload::TreasuryTransaction(payload)) = &block.payload {
+                    return Some((
+                        metadata.referenced_by_milestone_index,
+                        payload.input_milestone_id,
+                        payload.output_amount,
+                    ));
+                }
+            }
+            None
+        })
+        .collect::<Vec<_>>();
+
+    for batch in &payloads.into_iter().chunks(INSERT_BATCH_SIZE) {
+        db.collection::<TreasuryCollection>()
+            .insert_treasury_payloads(batch)
+            .await?;
+    }
+
+    for batch in &blocks_with_metadata.into_iter().chunks(INSERT_BATCH_SIZE) {
+        db.collection::<BlockCollection>()
+            .insert_blocks_with_metadata(batch)
+            .await?;
+    }
 
     Ok(())
 }

--- a/src/db/collections/ledger_update.rs
+++ b/src/db/collections/ledger_update.rs
@@ -14,9 +14,11 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::instrument;
 
-use super::INSERT_BATCH_SIZE;
 use crate::{
-    db::MongoDb,
+    db::{
+        mongodb::{InsertIgnoreDuplicatesExt, MongoCollectionExt, MongoDbCollection},
+        MongoDb,
+    },
     types::{
         ledger::{LedgerOutput, LedgerSpent, MilestoneIndexTimestamp},
         stardust::{
@@ -37,15 +39,28 @@ struct Id {
 
 /// Contains all information related to an output.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-struct LedgerUpdateDocument {
+pub struct LedgerUpdateDocument {
     _id: Id,
     address: Address,
     milestone_timestamp: MilestoneTimestamp,
 }
 
-impl LedgerUpdateDocument {
-    /// The stardust outputs collection name.
-    const COLLECTION: &'static str = "stardust_ledger_updates";
+/// The stardust ledger updates collection.
+pub struct LedgerUpdateCollection {
+    collection: mongodb::Collection<LedgerUpdateDocument>,
+}
+
+impl MongoDbCollection for LedgerUpdateCollection {
+    const NAME: &'static str = "stardust_ledger_updates";
+    type Document = LedgerUpdateDocument;
+
+    fn instantiate(_db: &MongoDb, collection: mongodb::Collection<Self::Document>) -> Self {
+        Self { collection }
+    }
+
+    fn collection(&self) -> &mongodb::Collection<Self::Document> {
+        &self.collection
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -103,94 +118,84 @@ fn oldest() -> Document {
 }
 
 /// Queries that are related to [`Output`](crate::types::stardust::block::Output)s.
-impl MongoDb {
+impl LedgerUpdateCollection {
     /// Creates ledger update indexes.
-    pub async fn create_ledger_update_indexes(&self) -> Result<(), Error> {
-        let collection = self
-            .db
-            .collection::<LedgerUpdateDocument>(LedgerUpdateDocument::COLLECTION);
-
-        collection
-            .create_index(
-                IndexModel::builder()
-                    .keys(newest())
-                    .options(
-                        IndexOptions::builder()
-                            .unique(true)
-                            .name("ledger_update_index".to_string())
-                            .build(),
-                    )
-                    .build(),
-                None,
-            )
-            .await?;
+    pub async fn create_indexes(&self) -> Result<(), Error> {
+        self.create_index(
+            IndexModel::builder()
+                .keys(newest())
+                .options(
+                    IndexOptions::builder()
+                        .unique(true)
+                        .name("ledger_update_index".to_string())
+                        .build(),
+                )
+                .build(),
+            None,
+        )
+        .await?;
 
         Ok(())
     }
 
     /// Inserts [`LedgerSpent`] updates.
     #[instrument(skip_all, err, level = "trace")]
-    pub async fn insert_spent_ledger_updates(&self, outputs: impl Iterator<Item = &LedgerSpent>) -> Result<(), Error> {
-        let ledger_updates = outputs
-            .filter_map(
-                |LedgerSpent {
-                     output: LedgerOutput { output_id, output, .. },
-                     spent_metadata,
-                 }| {
-                    // Ledger updates
-                    output.owning_address().map(|&address| LedgerUpdateDocument {
-                        _id: Id {
-                            milestone_index: spent_metadata.spent.milestone_index,
-                            output_id: *output_id,
-                            is_spent: true,
-                        },
-                        address,
-                        milestone_timestamp: spent_metadata.spent.milestone_timestamp,
-                    })
-                },
-            )
-            .collect::<Vec<_>>();
-        for batch in ledger_updates.chunks(INSERT_BATCH_SIZE) {
-            self.collection::<LedgerUpdateDocument>(LedgerUpdateDocument::COLLECTION)
-                .insert_many_ignore_duplicates(batch, InsertManyOptions::builder().ordered(false).build())
-                .await?;
-        }
+    pub async fn insert_spent_ledger_updates<'a, I>(&self, outputs: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = &'a LedgerSpent>,
+        I::IntoIter: Send + Sync,
+    {
+        let ledger_updates = outputs.into_iter().filter_map(
+            |LedgerSpent {
+                 output: LedgerOutput { output_id, output, .. },
+                 spent_metadata,
+             }| {
+                // Ledger updates
+                output.owning_address().map(|&address| LedgerUpdateDocument {
+                    _id: Id {
+                        milestone_index: spent_metadata.spent.milestone_index,
+                        output_id: *output_id,
+                        is_spent: true,
+                    },
+                    address,
+                    milestone_timestamp: spent_metadata.spent.milestone_timestamp,
+                })
+            },
+        );
+        self.insert_many_ignore_duplicates(ledger_updates, InsertManyOptions::builder().ordered(false).build())
+            .await?;
 
         Ok(())
     }
 
     /// Inserts unspent [`LedgerOutput`] updates.
     #[instrument(skip_all, err, level = "trace")]
-    pub async fn insert_unspent_ledger_updates(
-        &self,
-        outputs: impl Iterator<Item = &LedgerOutput>,
-    ) -> Result<(), Error> {
-        let ledger_updates = outputs
-            .filter_map(
-                |LedgerOutput {
-                     output_id,
-                     booked,
-                     output,
-                     ..
-                 }| {
-                    // Ledger updates
-                    output.owning_address().map(|&address| LedgerUpdateDocument {
-                        _id: Id {
-                            milestone_index: booked.milestone_index,
-                            output_id: *output_id,
-                            is_spent: false,
-                        },
-                        address,
-                        milestone_timestamp: booked.milestone_timestamp,
-                    })
-                },
-            )
-            .collect::<Vec<_>>();
-        for batch in ledger_updates.chunks(INSERT_BATCH_SIZE) {
-            self.collection::<LedgerUpdateDocument>(LedgerUpdateDocument::COLLECTION)
-                .insert_many_ignore_duplicates(batch, InsertManyOptions::builder().ordered(false).build())
-                .await?;
-        }
+    pub async fn insert_unspent_ledger_updates<'a, I>(&self, outputs: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = &'a LedgerOutput>,
+        I::IntoIter: Send + Sync,
+    {
+        let ledger_updates = outputs.into_iter().filter_map(
+            |LedgerOutput {
+                 output_id,
+                 booked,
+                 output,
+                 ..
+             }| {
+                // Ledger updates
+                output.owning_address().map(|&address| LedgerUpdateDocument {
+                    _id: Id {
+                        milestone_index: booked.milestone_index,
+                        output_id: *output_id,
+                        is_spent: false,
+                    },
+                    address,
+                    milestone_timestamp: booked.milestone_timestamp,
+                })
+            },
+        );
+        self.insert_many_ignore_duplicates(ledger_updates, InsertManyOptions::builder().ordered(false).build())
+            .await?;
 
         Ok(())
     }
@@ -226,23 +231,20 @@ impl MongoDb {
             queries.push(doc! { "$or": cursor_queries });
         }
 
-        self.db
-            .collection::<LedgerUpdateDocument>(LedgerUpdateDocument::COLLECTION)
-            .find(
+        Ok(self
+            .find::<LedgerUpdateDocument>(
                 doc! { "$and": queries },
                 FindOptions::builder().limit(page_size as i64).sort(sort).build(),
             )
-            .await
-            .map(|c| {
-                c.map_ok(|doc| LedgerUpdateByAddressRecord {
-                    at: MilestoneIndexTimestamp {
-                        milestone_index: doc._id.milestone_index,
-                        milestone_timestamp: doc.milestone_timestamp,
-                    },
-                    output_id: doc._id.output_id,
-                    is_spent: doc._id.is_spent,
-                })
-            })
+            .await?
+            .map_ok(|doc| LedgerUpdateByAddressRecord {
+                at: MilestoneIndexTimestamp {
+                    milestone_index: doc._id.milestone_index,
+                    milestone_timestamp: doc.milestone_timestamp,
+                },
+                output_id: doc._id.output_id,
+                is_spent: doc._id.is_spent,
+            }))
     }
 
     /// Streams updates to the ledger for a given milestone index (sorted by [`OutputId`]).
@@ -265,19 +267,16 @@ impl MongoDb {
             queries.push(doc! { "$or": cursor_queries });
         }
 
-        self.db
-            .collection::<LedgerUpdateDocument>(LedgerUpdateDocument::COLLECTION)
-            .find(
+        Ok(self
+            .find::<LedgerUpdateDocument>(
                 doc! { "$and": queries },
                 FindOptions::builder().limit(page_size as i64).sort(oldest()).build(),
             )
-            .await
-            .map(|c| {
-                c.map_ok(|doc| LedgerUpdateByMilestoneRecord {
-                    address: doc.address,
-                    output_id: doc._id.output_id,
-                    is_spent: doc._id.is_spent,
-                })
-            })
+            .await?
+            .map_ok(|doc| LedgerUpdateByMilestoneRecord {
+                address: doc.address,
+                output_id: doc._id.output_id,
+                is_spent: doc._id.is_spent,
+            }))
     }
 }

--- a/src/db/collections/milestone.rs
+++ b/src/db/collections/milestone.rs
@@ -3,9 +3,9 @@
 
 use std::ops::RangeInclusive;
 
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{Stream, TryStreamExt};
 use mongodb::{
-    bson::{self, doc},
+    bson::doc,
     error::Error,
     options::{FindOneOptions, FindOptions, IndexOptions},
     IndexModel,
@@ -14,7 +14,10 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::{
-    db::MongoDb,
+    db::{
+        mongodb::{MongoCollectionExt, MongoDbCollection},
+        MongoDb,
+    },
     types::{
         ledger::MilestoneIndexTimestamp,
         stardust::{
@@ -30,7 +33,7 @@ const BY_NEWEST: i32 = -1;
 
 /// A milestone's metadata.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct MilestoneDocument {
+pub struct MilestoneDocument {
     /// The [`MilestoneId`](MilestoneId) of the milestone.
     #[serde(rename = "_id")]
     milestone_id: MilestoneId,
@@ -40,9 +43,22 @@ struct MilestoneDocument {
     payload: MilestonePayload,
 }
 
-impl MilestoneDocument {
-    /// The stardust milestone collection name.
-    const COLLECTION: &'static str = "stardust_milestones";
+/// The stardust milestones collection.
+pub struct MilestoneCollection {
+    collection: mongodb::Collection<MilestoneDocument>,
+}
+
+impl MongoDbCollection for MilestoneCollection {
+    const NAME: &'static str = "stardust_milestones";
+    type Document = MilestoneDocument;
+
+    fn instantiate(_db: &MongoDb, collection: mongodb::Collection<Self::Document>) -> Self {
+        Self { collection }
+    }
+
+    fn collection(&self) -> &mongodb::Collection<Self::Document> {
+        &self.collection
+    }
 }
 
 /// An aggregation type that represents the ranges of completed milestones and gaps.
@@ -54,40 +70,36 @@ pub struct SyncData {
     pub gaps: Vec<RangeInclusive<MilestoneIndex>>,
 }
 
-impl MongoDb {
+impl MilestoneCollection {
     /// Creates ledger update indexes.
-    pub async fn create_milestone_indexes(&self) -> Result<(), Error> {
-        let collection = self.db.collection::<MilestoneDocument>(MilestoneDocument::COLLECTION);
+    pub async fn create_indexes(&self) -> Result<(), Error> {
+        self.create_index(
+            IndexModel::builder()
+                .keys(doc! { "at.milestone_index": BY_OLDEST })
+                .options(
+                    IndexOptions::builder()
+                        .unique(true)
+                        .name("milestone_idx_index".to_string())
+                        .build(),
+                )
+                .build(),
+            None,
+        )
+        .await?;
 
-        collection
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "at.milestone_index": BY_OLDEST })
-                    .options(
-                        IndexOptions::builder()
-                            .unique(true)
-                            .name("milestone_idx_index".to_string())
-                            .build(),
-                    )
-                    .build(),
-                None,
-            )
-            .await?;
-
-        collection
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "at.milestone_timestamp": BY_OLDEST })
-                    .options(
-                        IndexOptions::builder()
-                            .unique(true)
-                            .name("milestone_timestamp_index".to_string())
-                            .build(),
-                    )
-                    .build(),
-                None,
-            )
-            .await?;
+        self.create_index(
+            IndexModel::builder()
+                .keys(doc! { "at.milestone_timestamp": BY_OLDEST })
+                .options(
+                    IndexOptions::builder()
+                        .unique(true)
+                        .name("milestone_timestamp_index".to_string())
+                        .build(),
+                )
+                .build(),
+            None,
+        )
+        .await?;
 
         Ok(())
     }
@@ -97,40 +109,30 @@ impl MongoDb {
         &self,
         milestone_id: &MilestoneId,
     ) -> Result<Option<MilestonePayload>, Error> {
-        Ok(self
-            .db
-            .collection::<MilestonePayload>(MilestoneDocument::COLLECTION)
-            .aggregate(
-                vec![
-                    doc! { "$match": { "_id": milestone_id } },
-                    doc! { "$replaceWith": "$payload" },
-                ],
-                None,
-            )
-            .await?
-            .try_next()
-            .await?
-            .map(bson::from_document)
-            .transpose()?)
+        self.aggregate(
+            vec![
+                doc! { "$match": { "_id": milestone_id } },
+                doc! { "$replaceWith": "$payload" },
+            ],
+            None,
+        )
+        .await?
+        .try_next()
+        .await
     }
 
     /// Gets [`MilestonePayload`] of a milestone by the [`MilestoneIndex`].
     pub async fn get_milestone_payload(&self, index: MilestoneIndex) -> Result<Option<MilestonePayload>, Error> {
-        Ok(self
-            .db
-            .collection::<MilestonePayload>(MilestoneDocument::COLLECTION)
-            .aggregate(
-                vec![
-                    doc! { "$match": { "at.milestone_index": index } },
-                    doc! { "$replaceWith": "$payload" },
-                ],
-                None,
-            )
-            .await?
-            .try_next()
-            .await?
-            .map(bson::from_document)
-            .transpose()?)
+        self.aggregate(
+            vec![
+                doc! { "$match": { "at.milestone_index": index } },
+                doc! { "$replaceWith": "$payload" },
+            ],
+            None,
+        )
+        .await?
+        .try_next()
+        .await
     }
 
     /// Gets the id of a milestone by the [`MilestoneIndex`].
@@ -140,9 +142,7 @@ impl MongoDb {
             milestone_id: MilestoneId,
         }
         Ok(self
-            .db
-            .collection::<MilestoneIdResult>(MilestoneDocument::COLLECTION)
-            .find_one(
+            .find_one::<MilestoneIdResult>(
                 doc! { "at.milestone_index": index },
                 FindOneOptions::builder()
                     .projection(doc! {
@@ -172,10 +172,7 @@ impl MongoDb {
             payload,
         };
 
-        self.db
-            .collection::<MilestoneDocument>(MilestoneDocument::COLLECTION)
-            .insert_one(milestone_document, None)
-            .await?;
+        self.insert_one(milestone_document, None).await?;
 
         Ok(())
     }
@@ -185,24 +182,22 @@ impl MongoDb {
         &self,
         start_timestamp: MilestoneTimestamp,
     ) -> Result<Option<MilestoneIndexTimestamp>, Error> {
-        self.db
-            .collection::<MilestoneIndexTimestamp>(MilestoneDocument::COLLECTION)
-            .find(
-                doc! {
-                    "at.milestone_timestamp": { "$gte": start_timestamp },
-                },
-                FindOptions::builder()
-                    .sort(doc! { "at.milestone_index": 1 })
-                    .limit(1)
-                    .projection(doc! {
-                        "milestone_index": "$at.milestone_index",
-                        "milestone_timestamp": "$at.milestone_timestamp",
-                    })
-                    .build(),
-            )
-            .await?
-            .try_next()
-            .await
+        self.find(
+            doc! {
+                "at.milestone_timestamp": { "$gte": start_timestamp },
+            },
+            FindOptions::builder()
+                .sort(doc! { "at.milestone_index": 1 })
+                .limit(1)
+                .projection(doc! {
+                    "milestone_index": "$at.milestone_index",
+                    "milestone_timestamp": "$at.milestone_timestamp",
+                })
+                .build(),
+        )
+        .await?
+        .try_next()
+        .await
     }
 
     /// Find the end milestone.
@@ -210,58 +205,52 @@ impl MongoDb {
         &self,
         end_timestamp: MilestoneTimestamp,
     ) -> Result<Option<MilestoneIndexTimestamp>, Error> {
-        self.db
-            .collection::<MilestoneIndexTimestamp>(MilestoneDocument::COLLECTION)
-            .find(
-                doc! {
-                    "at.milestone_timestamp": { "$lte": end_timestamp },
-                },
-                FindOptions::builder()
-                    .sort(doc! { "at.milestone_index": -1 })
-                    .limit(1)
-                    .projection(doc! {
-                        "milestone_index": "$at.milestone_index",
-                        "milestone_timestamp": "$at.milestone_timestamp",
-                    })
-                    .build(),
-            )
-            .await?
-            .try_next()
-            .await
+        self.find(
+            doc! {
+                "at.milestone_timestamp": { "$lte": end_timestamp },
+            },
+            FindOptions::builder()
+                .sort(doc! { "at.milestone_index": -1 })
+                .limit(1)
+                .projection(doc! {
+                    "milestone_index": "$at.milestone_index",
+                    "milestone_timestamp": "$at.milestone_timestamp",
+                })
+                .build(),
+        )
+        .await?
+        .try_next()
+        .await
     }
 
     /// Find the newest milestone.
     pub async fn get_newest_milestone(&self) -> Result<Option<MilestoneIndexTimestamp>, Error> {
-        self.db
-            .collection::<MilestoneIndexTimestamp>(MilestoneDocument::COLLECTION)
-            .find_one(
-                doc! {},
-                FindOneOptions::builder()
-                    .sort(doc! { "at.milestone_index": BY_NEWEST })
-                    .projection(doc! {
-                        "milestone_index": "$at.milestone_index",
-                        "milestone_timestamp": "$at.milestone_timestamp",
-                    })
-                    .build(),
-            )
-            .await
+        self.find_one(
+            doc! {},
+            FindOneOptions::builder()
+                .sort(doc! { "at.milestone_index": BY_NEWEST })
+                .projection(doc! {
+                    "milestone_index": "$at.milestone_index",
+                    "milestone_timestamp": "$at.milestone_timestamp",
+                })
+                .build(),
+        )
+        .await
     }
 
     /// Find the oldest milestone.
     pub async fn get_oldest_milestone(&self) -> Result<Option<MilestoneIndexTimestamp>, Error> {
-        self.db
-            .collection::<MilestoneIndexTimestamp>(MilestoneDocument::COLLECTION)
-            .find_one(
-                doc! {},
-                FindOneOptions::builder()
-                    .sort(doc! { "at.milestone_index": BY_OLDEST })
-                    .projection(doc! {
-                        "milestone_index": "$at.milestone_index",
-                        "milestone_timestamp": "$at.milestone_timestamp",
-                    })
-                    .build(),
-            )
-            .await
+        self.find_one(
+            doc! {},
+            FindOneOptions::builder()
+                .sort(doc! { "at.milestone_index": BY_OLDEST })
+                .projection(doc! {
+                    "milestone_index": "$at.milestone_index",
+                    "milestone_timestamp": "$at.milestone_timestamp",
+                })
+                .build(),
+        )
+        .await
     }
 
     /// Gets the current ledger index.
@@ -280,9 +269,7 @@ impl MongoDb {
         }
 
         Ok(self
-            .db
-            .collection::<ReceiptAtIndex>(MilestoneDocument::COLLECTION)
-            .aggregate(
+            .aggregate::<ReceiptAtIndex>(
                 vec![
                     doc! { "$unwind": "payload.essence.options"},
                     doc! { "$match": {
@@ -297,10 +284,7 @@ impl MongoDb {
                 None,
             )
             .await?
-            .map(|doc| {
-                let ReceiptAtIndex { receipt, index } = bson::from_document::<ReceiptAtIndex>(doc?)?;
-                Ok((receipt, index))
-            }))
+            .map_ok(|ReceiptAtIndex { receipt, index }| (receipt, index)))
     }
 
     /// Streams all available receipt milestone options together with their corresponding `MilestoneIndex` that were
@@ -316,8 +300,6 @@ impl MongoDb {
         }
 
         Ok(self
-            .db
-            .collection::<ReceiptAtIndex>(MilestoneDocument::COLLECTION)
             .aggregate(
                 vec![
                     doc! { "$unwind": "payload.essence.options"},
@@ -333,9 +315,6 @@ impl MongoDb {
                 None,
             )
             .await?
-            .map(|doc| {
-                let ReceiptAtIndex { receipt, index } = bson::from_document::<ReceiptAtIndex>(doc?)?;
-                Ok((receipt, index))
-            }))
+            .map_ok(|ReceiptAtIndex { receipt, index }| (receipt, index)))
     }
 }

--- a/src/db/collections/mod.rs
+++ b/src/db/collections/mod.rs
@@ -15,21 +15,23 @@ mod protocol_update;
 mod treasury;
 
 pub use self::{
-    ledger_update::{LedgerUpdateByAddressRecord, LedgerUpdateByMilestoneRecord, ParseSortError, SortOrder},
-    milestone::SyncData,
+    block::BlockCollection,
+    ledger_update::{
+        LedgerUpdateByAddressRecord, LedgerUpdateByMilestoneRecord, LedgerUpdateCollection, ParseSortError, SortOrder,
+    },
+    milestone::{MilestoneCollection, SyncData},
     outputs::{
         AddressStat, AliasOutputsQuery, BasicOutputsQuery, DistributionStat, FoundryOutputsQuery, IndexedId,
-        NftOutputsQuery, OutputMetadataResult, OutputWithMetadataResult, OutputsResult, UtxoChangesResult,
+        NftOutputsQuery, OutputCollection, OutputMetadataResult, OutputWithMetadataResult, OutputsResult,
+        UtxoChangesResult,
     },
-    treasury::TreasuryResult,
+    protocol_update::ProtocolUpdateCollection,
+    treasury::{TreasuryCollection, TreasuryResult},
 };
 use crate::types::stardust::block::{
     output::{AliasOutput, BasicOutput, FoundryOutput, NftOutput},
     payload::{MilestonePayload, TaggedDataPayload, TransactionPayload, TreasuryTransactionPayload},
 };
-
-/// Batch size for `insert_many` operations.
-pub const INSERT_BATCH_SIZE: usize = 10000;
 
 /// Helper to specify a kind for an output type.
 pub trait OutputKind {

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -3,9 +3,11 @@
 
 mod indexer;
 
-use futures::{StreamExt, TryStreamExt};
+use std::borrow::Borrow;
+
+use futures::TryStreamExt;
 use mongodb::{
-    bson::{self, doc, to_bson, to_document},
+    bson::{doc, to_bson, to_document},
     error::Error,
     options::{IndexOptions, InsertManyOptions},
     IndexModel,
@@ -16,9 +18,12 @@ use tracing::instrument;
 pub use self::indexer::{
     AliasOutputsQuery, BasicOutputsQuery, FoundryOutputsQuery, IndexedId, NftOutputsQuery, OutputsResult,
 };
-use super::{OutputKind, INSERT_BATCH_SIZE};
+use super::{milestone::MilestoneCollection, protocol_update::ProtocolUpdateCollection, OutputKind};
 use crate::{
-    db::MongoDb,
+    db::{
+        mongodb::{InsertIgnoreDuplicatesExt, MongoCollectionExt, MongoDbCollection},
+        MongoDb,
+    },
     types::{
         ledger::{
             LedgerOutput, LedgerSpent, MilestoneIndexTimestamp, OutputMetadata, RentStructureBytes, SpentMetadata,
@@ -33,7 +38,7 @@ use crate::{
 
 /// Chronicle Output record.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct OutputDocument {
+pub struct OutputDocument {
     #[serde(rename = "_id")]
     output_id: OutputId,
     output: Output,
@@ -41,9 +46,30 @@ struct OutputDocument {
     details: OutputDetails,
 }
 
-impl OutputDocument {
-    /// The stardust outputs collection name.
-    const COLLECTION: &'static str = "stardust_outputs";
+/// The stardust outputs collection.
+pub struct OutputCollection {
+    db: mongodb::Database,
+    collection: mongodb::Collection<OutputDocument>,
+    milestone_collection: MilestoneCollection,
+    protocol_param_collection: ProtocolUpdateCollection,
+}
+
+impl MongoDbCollection for OutputCollection {
+    const NAME: &'static str = "stardust_outputs";
+    type Document = OutputDocument;
+
+    fn instantiate(db: &MongoDb, collection: mongodb::Collection<Self::Document>) -> Self {
+        Self {
+            db: db.db.clone(),
+            collection,
+            milestone_collection: db.collection(),
+            protocol_param_collection: db.collection(),
+        }
+    }
+
+    fn collection(&self) -> &mongodb::Collection<Self::Document> {
+        &self.collection
+    }
 }
 
 /// Precalculated info and other output details.
@@ -119,30 +145,27 @@ pub struct UtxoChangesResult {
 }
 
 /// Implements the queries for the core API.
-impl MongoDb {
+impl OutputCollection {
     /// Creates output indexes.
-    pub async fn create_output_indexes(&self) -> Result<(), Error> {
-        let collection = self.db.collection::<OutputDocument>(OutputDocument::COLLECTION);
+    pub async fn create_indexes(&self) -> Result<(), Error> {
+        self.create_index(
+            IndexModel::builder()
+                .keys(doc! { "details.address": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .unique(false)
+                        .name("address_index".to_string())
+                        .partial_filter_expression(doc! {
+                            "details.address": { "$exists": true },
+                        })
+                        .build(),
+                )
+                .build(),
+            None,
+        )
+        .await?;
 
-        collection
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "details.address": 1 })
-                    .options(
-                        IndexOptions::builder()
-                            .unique(false)
-                            .name("address_index".to_string())
-                            .partial_filter_expression(doc! {
-                                "details.address": { "$exists": true },
-                            })
-                            .build(),
-                    )
-                    .build(),
-                None,
-            )
-            .await?;
-
-        self.create_indexer_output_indexes().await?;
+        self.create_indexer_indexes().await?;
 
         Ok(())
     }
@@ -150,9 +173,10 @@ impl MongoDb {
     /// Upserts [`Outputs`](crate::types::stardust::block::Output) with their
     /// [`OutputMetadata`](crate::types::ledger::OutputMetadata).
     #[instrument(skip_all, err, level = "trace")]
-    pub async fn update_spent_outputs(&self, outputs: impl Iterator<Item = &LedgerSpent>) -> Result<(), Error> {
+    pub async fn update_spent_outputs(&self, outputs: impl IntoIterator<Item = &LedgerSpent>) -> Result<(), Error> {
         // TODO: Replace `db.run_command` once the `BulkWrite` API lands in the Rust driver.
         let update_docs = outputs
+            .into_iter()
             .map(|output| {
                 Ok(doc! {
                     "q": { "_id": output.output.output_id },
@@ -164,7 +188,7 @@ impl MongoDb {
 
         if !update_docs.is_empty() {
             let mut command = doc! {
-                "update": OutputDocument::COLLECTION,
+                "update": Self::NAME,
                 "updates": update_docs,
             };
             if let Some(ref write_concern) = self.db.write_concern() {
@@ -180,36 +204,33 @@ impl MongoDb {
     /// Inserts [`Outputs`](crate::types::stardust::block::Output) with their
     /// [`OutputMetadata`](crate::types::ledger::OutputMetadata).
     #[instrument(skip_all, err, level = "trace")]
-    pub async fn insert_unspent_outputs(&self, outputs: impl Iterator<Item = &LedgerOutput>) -> Result<(), Error> {
-        let outputs = outputs.map(Into::into).collect::<Vec<_>>();
+    pub async fn insert_unspent_outputs<I, B>(&self, outputs: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = B>,
+        I::IntoIter: Send + Sync,
+        B: Borrow<LedgerOutput>,
+    {
+        self.insert_many_ignore_duplicates(
+            outputs.into_iter().map(|d| OutputDocument::from(d.borrow())),
+            InsertManyOptions::builder().ordered(false).build(),
+        )
+        .await?;
 
-        for batch in outputs.chunks(INSERT_BATCH_SIZE) {
-            self.collection::<OutputDocument>(OutputDocument::COLLECTION)
-                .insert_many_ignore_duplicates(batch, InsertManyOptions::builder().ordered(false).build())
-                .await?;
-        }
         Ok(())
     }
 
     /// Get an [`Output`] by [`OutputId`].
     pub async fn get_output(&self, output_id: &OutputId) -> Result<Option<Output>, Error> {
-        let output = self
-            .db
-            .collection::<Output>(OutputDocument::COLLECTION)
-            .aggregate(
-                vec![
-                    doc! { "$match": { "_id": output_id } },
-                    doc! { "$replaceWith": "$output" },
-                ],
-                None,
-            )
-            .await?
-            .try_next()
-            .await?
-            .map(bson::from_document)
-            .transpose()?;
-
-        Ok(output)
+        self.aggregate(
+            vec![
+                doc! { "$match": { "_id": output_id } },
+                doc! { "$replaceWith": "$output" },
+            ],
+            None,
+        )
+        .await?
+        .try_next()
+        .await
     }
 
     /// Get an [`Output`] with its [`OutputMetadata`] by [`OutputId`].
@@ -217,11 +238,9 @@ impl MongoDb {
         &self,
         output_id: &OutputId,
     ) -> Result<Option<OutputWithMetadataResult>, Error> {
-        let ledger_index = self.get_ledger_index().await?;
+        let ledger_index = self.milestone_collection.get_ledger_index().await?;
         if let Some(ledger_index) = ledger_index {
-            let output = self
-                .db
-                .collection::<OutputWithMetadataResult>(OutputDocument::COLLECTION)
+            Ok(self
                 .aggregate(
                     vec![
                         doc! { "$match": {
@@ -245,11 +264,7 @@ impl MongoDb {
                 )
                 .await?
                 .try_next()
-                .await?
-                .map(bson::from_document)
-                .transpose()?;
-
-            Ok(output)
+                .await?)
         } else {
             Ok(None)
         }
@@ -257,11 +272,9 @@ impl MongoDb {
 
     /// Get an [`OutputMetadata`] by [`OutputId`].
     pub async fn get_output_metadata(&self, output_id: &OutputId) -> Result<Option<OutputMetadataResult>, Error> {
-        let ledger_index = self.get_ledger_index().await?;
+        let ledger_index = self.milestone_collection.get_ledger_index().await?;
         if let Some(ledger_index) = ledger_index {
-            let metadata = self
-                .db
-                .collection::<OutputMetadataResult>(OutputDocument::COLLECTION)
+            Ok(self
                 .aggregate(
                     vec![
                         doc! { "$match": {
@@ -282,11 +295,7 @@ impl MongoDb {
                 )
                 .await?
                 .try_next()
-                .await?
-                .map(bson::from_document)
-                .transpose()?;
-
-            Ok(metadata)
+                .await?)
         } else {
             Ok(None)
         }
@@ -297,35 +306,26 @@ impl MongoDb {
         &self,
         output_id: &OutputId,
     ) -> Result<Option<SpentMetadata>, Error> {
-        let metadata = self
-            .db
-            .collection::<SpentMetadata>(OutputDocument::COLLECTION)
-            .aggregate(
-                vec![
-                    doc! { "$match": {
-                        "_id": &output_id,
-                        "metadata.spent_metadata": { "$ne": null }
-                    } },
-                    doc! { "$replaceWith": "$metadata.spent_metadata" },
-                ],
-                None,
-            )
-            .await?
-            .try_next()
-            .await?
-            .map(bson::from_document)
-            .transpose()?;
-
-        Ok(metadata)
+        self.aggregate(
+            vec![
+                doc! { "$match": {
+                    "_id": &output_id,
+                    "metadata.spent_metadata": { "$ne": null }
+                } },
+                doc! { "$replaceWith": "$metadata.spent_metadata" },
+            ],
+            None,
+        )
+        .await?
+        .try_next()
+        .await
     }
 
     /// Sums the amounts of all outputs owned by the given [`Address`](crate::types::stardust::block::Address).
     pub async fn get_address_balance(&self, address: Address) -> Result<Option<BalanceResult>, Error> {
-        let ledger_index = self.get_ledger_index().await?;
+        let ledger_index = self.milestone_collection.get_ledger_index().await?;
         if let Some(ledger_index) = ledger_index {
-            let balances = self
-                .db
-                .collection::<BalanceResult>(OutputDocument::COLLECTION)
+            Ok(self
                 .aggregate(
                     vec![
                         // Look at all (at ledger index o'clock) unspent output documents for the given address.
@@ -354,11 +354,7 @@ impl MongoDb {
                 )
                 .await?
                 .try_next()
-                .await?
-                .map(bson::from_document::<BalanceResult>)
-                .transpose()?;
-
-            Ok(balances)
+                .await?)
         } else {
             Ok(None)
         }
@@ -368,32 +364,28 @@ impl MongoDb {
     /// `index`. It returns `None` if the provided `index` is out of bounds (beyond Chronicle's ledger index). If
     /// the associated milestone did not perform any changes to the ledger, the returned `Vec`s will be empty.
     pub async fn get_utxo_changes(&self, index: MilestoneIndex) -> Result<Option<UtxoChangesResult>, Error> {
-        if let Some(ledger_index) = self.get_ledger_index().await? {
+        if let Some(ledger_index) = self.milestone_collection.get_ledger_index().await? {
             if index > ledger_index {
                 Ok(None)
             } else {
                 Ok(Some(
-                    self.db
-                        .collection::<UtxoChangesResult>(OutputDocument::COLLECTION)
-                        .aggregate(
-                            vec![doc! { "$facet": {
-                                "created_outputs": [
-                                    { "$match": { "metadata.booked.milestone_index": index  } },
-                                    { "$replaceWith": "$_id" },
-                                ],
-                                "consumed_outputs": [
-                                    { "$match": { "metadata.spent_metadata.spent.milestone_index": index } },
-                                    { "$replaceWith": "$_id" },
-                                ],
-                            } }],
-                            None,
-                        )
-                        .await?
-                        .try_next()
-                        .await?
-                        .map(bson::from_document::<UtxoChangesResult>)
-                        .transpose()?
-                        .unwrap_or_default(),
+                    self.aggregate(
+                        vec![doc! { "$facet": {
+                            "created_outputs": [
+                                { "$match": { "metadata.booked.milestone_index": index  } },
+                                { "$replaceWith": "$_id" },
+                            ],
+                            "consumed_outputs": [
+                                { "$match": { "metadata.spent_metadata.spent.milestone_index": index } },
+                                { "$replaceWith": "$_id" },
+                            ],
+                        } }],
+                        None,
+                    )
+                    .await?
+                    .try_next()
+                    .await?
+                    .unwrap_or_default(),
                 ))
             }
         } else {
@@ -408,7 +400,7 @@ pub struct OutputAnalyticsResult {
     pub total_value: String,
 }
 
-impl MongoDb {
+impl OutputCollection {
     /// Gathers output analytics.
     pub async fn get_output_analytics<O: OutputKind>(
         &self,
@@ -425,8 +417,6 @@ impl MongoDb {
             queries.push(doc! { "output.kind": kind });
         }
         Ok(self
-            .db
-            .collection::<OutputAnalyticsResult>(OutputDocument::COLLECTION)
             .aggregate(
                 vec![
                     doc! { "$match": { "$and": queries } },
@@ -445,8 +435,6 @@ impl MongoDb {
             .await?
             .try_next()
             .await?
-            .map(bson::from_document)
-            .transpose()?
             .unwrap_or_default())
     }
 
@@ -456,7 +444,7 @@ impl MongoDb {
         ledger_index: Option<MilestoneIndex>,
     ) -> Result<Option<OutputAnalyticsResult>, Error> {
         let ledger_index = match ledger_index {
-            None => self.get_ledger_index().await?,
+            None => self.milestone_collection.get_ledger_index().await?,
             i => i,
         };
         if let Some(ledger_index) = ledger_index {
@@ -471,29 +459,25 @@ impl MongoDb {
                 queries.push(doc! { "output.kind": kind });
             }
             Ok(Some(
-                self.db
-                    .collection::<OutputAnalyticsResult>(OutputDocument::COLLECTION)
-                    .aggregate(
-                        vec![
-                            doc! { "$match": { "$and": queries } },
-                            doc! { "$group" : {
-                                "_id": null,
-                                "count": { "$sum": 1 },
-                                "total_value": { "$sum": { "$toDecimal": "$output.amount" } },
-                            } },
-                            doc! { "$project": {
-                                "count": 1,
-                                "total_value": { "$toString": "$total_value" },
-                            } },
-                        ],
-                        None,
-                    )
-                    .await?
-                    .try_next()
-                    .await?
-                    .map(bson::from_document)
-                    .transpose()?
-                    .unwrap_or_default(),
+                self.aggregate(
+                    vec![
+                        doc! { "$match": { "$and": queries } },
+                        doc! { "$group" : {
+                            "_id": null,
+                            "count": { "$sum": 1 },
+                            "total_value": { "$sum": { "$toDecimal": "$output.amount" } },
+                        } },
+                        doc! { "$project": {
+                            "count": 1,
+                            "total_value": { "$toString": "$total_value" },
+                        } },
+                    ],
+                    None,
+                )
+                .await?
+                .try_next()
+                .await?
+                .unwrap_or_default(),
             ))
         } else {
             Ok(None)
@@ -508,7 +492,7 @@ pub struct OutputDiffAnalyticsResult {
     pub burned_count: u64,
 }
 
-impl MongoDb {
+impl OutputCollection {
     /// Gathers nft output analytics.
     pub async fn get_nft_output_analytics(
         &self,
@@ -516,8 +500,6 @@ impl MongoDb {
         end_index: Option<MilestoneIndex>,
     ) -> Result<OutputDiffAnalyticsResult, Error> {
         Ok(self
-            .db
-            .collection::<OutputDiffAnalyticsResult>(OutputDocument::COLLECTION)
             .aggregate(
                 vec![
                     doc! { "$match": {
@@ -560,8 +542,6 @@ impl MongoDb {
             .await?
             .try_next()
             .await?
-            .map(bson::from_document)
-            .transpose()?
             .unwrap_or_default())
     }
 
@@ -572,8 +552,6 @@ impl MongoDb {
         end_index: Option<MilestoneIndex>,
     ) -> Result<OutputDiffAnalyticsResult, Error> {
         Ok(self
-            .db
-            .collection::<OutputDiffAnalyticsResult>(OutputDocument::COLLECTION)
             .aggregate(
                 vec![
                     doc! { "$match": {
@@ -616,8 +594,6 @@ impl MongoDb {
             .await?
             .try_next()
             .await?
-            .map(bson::from_document)
-            .transpose()?
             .unwrap_or_default())
     }
 }
@@ -634,18 +610,22 @@ pub struct StorageDepositAnalyticsResult {
     pub rent_structure: RentStructure,
 }
 
-impl MongoDb {
+impl OutputCollection {
     /// Gathers byte cost and storage deposit analytics.
     pub async fn get_storage_deposit_analytics(
         &self,
         ledger_index: Option<MilestoneIndex>,
     ) -> Result<Option<StorageDepositAnalyticsResult>, Error> {
         let ledger_index = match ledger_index {
-            None => self.get_ledger_index().await?,
+            None => self.milestone_collection.get_ledger_index().await?,
             i => i,
         };
         if let Some(ledger_index) = ledger_index {
-            if let Some(protocol_params) = self.get_protocol_parameters_for_ledger_index(ledger_index).await? {
+            if let Some(protocol_params) = self
+                .protocol_param_collection
+                .get_protocol_parameters_for_ledger_index(ledger_index)
+                .await?
+            {
                 #[derive(Default, Deserialize)]
                 struct StorageDepositAnalytics {
                     output_count: u64,
@@ -659,9 +639,7 @@ impl MongoDb {
                 let rent_structure = protocol_params.parameters.rent_structure;
 
                 let res = self
-                    .db
-                    .collection::<StorageDepositAnalytics>(OutputDocument::COLLECTION)
-                    .aggregate(
+                    .aggregate::<StorageDepositAnalytics>(
                         vec![
                             doc! { "$match": {
                                 "metadata.booked.milestone_index": { "$lte": ledger_index },
@@ -723,8 +701,6 @@ impl MongoDb {
                     .await?
                     .try_next()
                     .await?
-                    .map(bson::from_document::<StorageDepositAnalytics>)
-                    .transpose()?
                     .unwrap_or_default();
 
                 Ok(Some(StorageDepositAnalyticsResult {
@@ -758,7 +734,7 @@ pub struct AddressAnalyticsResult {
     pub sending_addresses: u64,
 }
 
-impl MongoDb {
+impl OutputCollection {
     /// Create aggregate statistics of all addresses.
     pub async fn get_address_analytics(
         &self,
@@ -766,8 +742,6 @@ impl MongoDb {
         end_index: Option<MilestoneIndex>,
     ) -> Result<AddressAnalyticsResult, Error> {
         Ok(self
-            .db
-            .collection::<AddressAnalyticsResult>(OutputDocument::COLLECTION)
             .aggregate(
                 vec![
                     doc! { "$match": {
@@ -826,8 +800,6 @@ impl MongoDb {
             .await?
             .try_next()
             .await?
-            .map(bson::from_document)
-            .transpose()?
             .unwrap_or_default())
     }
 }
@@ -862,7 +834,7 @@ pub struct DistributionStat {
     pub total_balance: String,
 }
 
-impl MongoDb {
+impl OutputCollection {
     /// Create richest address statistics.
     pub async fn get_richest_addresses(
         &self,
@@ -870,13 +842,11 @@ impl MongoDb {
         top: usize,
     ) -> Result<Option<RichestAddresses>, Error> {
         let ledger_index = match ledger_index {
-            None => self.get_ledger_index().await?,
+            None => self.milestone_collection.get_ledger_index().await?,
             i => i,
         };
         if let Some(ledger_index) = ledger_index {
             let top = self
-                .db
-                .collection::<bson::Document>(OutputDocument::COLLECTION)
                 .aggregate(
                     vec![
                         doc! { "$match": {
@@ -902,7 +872,6 @@ impl MongoDb {
                     None,
                 )
                 .await?
-                .map(|doc| Result::<_, Error>::Ok(bson::from_document(doc?)?))
                 .try_collect()
                 .await?;
             Ok(Some(RichestAddresses { top, ledger_index }))
@@ -917,13 +886,11 @@ impl MongoDb {
         ledger_index: Option<MilestoneIndex>,
     ) -> Result<Option<TokenDistribution>, Error> {
         let ledger_index = match ledger_index {
-            None => self.get_ledger_index().await?,
+            None => self.milestone_collection.get_ledger_index().await?,
             i => i,
         };
         if let Some(ledger_index) = ledger_index {
             let distribution = self
-                .db
-                .collection::<bson::Document>(OutputDocument::COLLECTION)
                 .aggregate(
                     vec![
                         doc! { "$match": {
@@ -955,7 +922,6 @@ impl MongoDb {
                     None,
                 )
                 .await?
-                .map(|doc| Result::<_, Error>::Ok(bson::from_document(doc?)?))
                 .try_collect()
                 .await?;
             Ok(Some(TokenDistribution {

--- a/src/db/mongodb.rs
+++ b/src/db/mongodb.rs
@@ -5,13 +5,19 @@
 
 use std::borrow::Borrow;
 
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
 use mongodb::{
-    bson::{doc, Document},
+    bson::{self, doc, Document},
     error::Error,
-    options::{ClientOptions, Credential, InsertManyOptions},
-    Client,
+    options::{
+        AggregateOptions, ClientOptions, CreateIndexOptions, Credential, FindOneOptions, FindOptions,
+        InsertManyOptions, InsertOneOptions, ReplaceOptions,
+    },
+    results::{CreateIndexResult, InsertManyResult, InsertOneResult, UpdateResult},
+    Client, Cursor, IndexModel,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 const DUPLICATE_KEY_CODE: i32 = 11000;
 
@@ -49,9 +55,9 @@ impl MongoDb {
         })
     }
 
-    /// Gets a collection of the provided type with the given name.
-    pub fn collection<T>(&self, name: impl AsRef<str>) -> MongoDbCollection<T> {
-        MongoDbCollection(self.db.collection(name.as_ref()))
+    /// Gets a collection of the provided type.
+    pub fn collection<T: MongoDbCollection>(&self) -> T {
+        T::instantiate(self, self.db.collection(T::NAME))
     }
 
     /// Clears all the collections from the database.
@@ -106,47 +112,6 @@ impl MongoDb {
     }
 }
 
-pub struct MongoDbCollection<T>(mongodb::Collection<T>);
-
-pub struct InsertResult {
-    pub ignored: usize,
-}
-
-impl<T: Serialize> MongoDbCollection<T> {
-    /// Inserts many records and ignores duplicate key errors.
-    pub async fn insert_many_ignore_duplicates(
-        &self,
-        docs: impl IntoIterator<Item = impl Borrow<T>>,
-        options: impl Into<Option<InsertManyOptions>>,
-    ) -> Result<InsertResult, Error> {
-        use mongodb::error::ErrorKind;
-        match self.insert_many(docs, options).await {
-            Ok(_) => Ok(InsertResult { ignored: 0 }),
-            Err(e) => match &*e.kind {
-                ErrorKind::BulkWrite(b) => {
-                    if let Some(write_errs) = &b.write_errors {
-                        if write_errs.iter().all(|e| e.code == DUPLICATE_KEY_CODE) {
-                            return Ok(InsertResult {
-                                ignored: write_errs.len(),
-                            });
-                        }
-                    }
-                    Err(e)
-                }
-                _ => Err(e),
-            },
-        }
-    }
-}
-
-impl<T> std::ops::Deref for MongoDbCollection<T> {
-    type Target = mongodb::Collection<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 /// The [`MongoDb`] config.
 #[must_use]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -172,6 +137,128 @@ impl Default for MongoDbConfig {
             password: None,
             database_name: MongoDb::DEFAULT_NAME.to_string(),
             min_pool_size: None,
+        }
+    }
+}
+
+pub trait MongoDbCollection {
+    /// The collection name.
+    const NAME: &'static str;
+    /// The document schema.
+    type Document: Send + Sync;
+
+    fn instantiate(db: &MongoDb, collection: mongodb::Collection<Self::Document>) -> Self;
+
+    fn collection(&self) -> &mongodb::Collection<Self::Document>;
+
+    fn with_type<T>(&self) -> mongodb::Collection<T> {
+        self.collection().clone_with_type()
+    }
+}
+
+#[async_trait]
+pub trait MongoCollectionExt: MongoDbCollection {
+    async fn create_index(
+        &self,
+        index: IndexModel,
+        options: impl Into<Option<CreateIndexOptions>> + Send + Sync,
+    ) -> Result<CreateIndexResult, Error> {
+        self.collection().create_index(index, options).await
+    }
+
+    async fn aggregate<T: DeserializeOwned>(
+        &self,
+        pipeline: impl IntoIterator<Item = Document> + Send + Sync,
+        options: impl Into<Option<AggregateOptions>> + Send + Sync,
+    ) -> Result<Box<dyn Stream<Item = Result<T, Error>> + Unpin + Send>, Error> {
+        Ok(Box::new(
+            self.collection()
+                .aggregate(pipeline, options)
+                .await?
+                .map(|doc| Ok(bson::from_document::<T>(doc?)?)),
+        ))
+    }
+
+    async fn find<T: Send + Sync>(
+        &self,
+        filter: impl Into<Option<Document>> + Send + Sync,
+        options: impl Into<Option<FindOptions>> + Send + Sync,
+    ) -> Result<Cursor<T>, Error> {
+        self.with_type().find(filter, options).await
+    }
+
+    async fn find_one<T: DeserializeOwned + Unpin + Send + Sync>(
+        &self,
+        filter: impl Into<Option<Document>> + Send + Sync,
+        options: impl Into<Option<FindOneOptions>> + Send + Sync,
+    ) -> Result<Option<T>, Error> {
+        self.with_type().find_one(filter, options).await
+    }
+
+    async fn insert_many<T: Serialize + Send + Sync>(
+        &self,
+        docs: impl IntoIterator<Item = impl Borrow<T> + Send + Sync> + Send + Sync,
+        options: impl Into<Option<InsertManyOptions>> + Send + Sync,
+    ) -> Result<InsertManyResult, Error> {
+        self.with_type().insert_many(docs, options).await
+    }
+
+    async fn insert_one<T: Serialize + Send + Sync>(
+        &self,
+        doc: impl Borrow<T> + Send + Sync,
+        options: impl Into<Option<InsertOneOptions>> + Send + Sync,
+    ) -> Result<InsertOneResult, Error> {
+        self.with_type().insert_one(doc, options).await
+    }
+    async fn replace_one<T: Serialize + Send + Sync>(
+        &self,
+        query: Document,
+        replacement: impl Borrow<T> + Send + Sync,
+        options: impl Into<Option<ReplaceOptions>> + Send + Sync,
+    ) -> Result<UpdateResult, Error> {
+        self.with_type().replace_one(query, replacement, options).await
+    }
+}
+impl<T: MongoDbCollection> MongoCollectionExt for T {}
+
+pub struct InsertResult {
+    pub ignored: usize,
+}
+
+#[async_trait]
+pub trait InsertIgnoreDuplicatesExt<T> {
+    /// Inserts many records and ignores duplicate key errors.
+    async fn insert_many_ignore_duplicates(
+        &self,
+        docs: impl IntoIterator<Item = impl Borrow<T> + Send + Sync> + Send + Sync,
+        options: impl Into<Option<InsertManyOptions>> + Send + Sync,
+    ) -> Result<InsertResult, Error>;
+}
+
+#[async_trait]
+impl<T: MongoCollectionExt + Send + Sync, D: Serialize + Send + Sync> InsertIgnoreDuplicatesExt<D> for T {
+    /// Inserts many records and ignores duplicate key errors.
+    async fn insert_many_ignore_duplicates(
+        &self,
+        docs: impl IntoIterator<Item = impl Borrow<D> + Send + Sync> + Send + Sync,
+        options: impl Into<Option<InsertManyOptions>> + Send + Sync,
+    ) -> Result<InsertResult, Error> {
+        use mongodb::error::ErrorKind;
+        match self.insert_many(docs, options).await {
+            Ok(_) => Ok(InsertResult { ignored: 0 }),
+            Err(e) => match &*e.kind {
+                ErrorKind::BulkWrite(b) => {
+                    if let Some(write_errs) = &b.write_errors {
+                        if write_errs.iter().all(|e| e.code == DUPLICATE_KEY_CODE) {
+                            return Ok(InsertResult {
+                                ignored: write_errs.len(),
+                            });
+                        }
+                    }
+                    Err(e)
+                }
+                _ => Err(e),
+            },
         }
     }
 }

--- a/tests/milestones.rs
+++ b/tests/milestones.rs
@@ -4,14 +4,18 @@
 mod common;
 
 use bee_block_stardust as bee;
-use chronicle::types::stardust::{block::payload::MilestoneId, util::payload::milestone::get_test_milestone_payload};
+use chronicle::{
+    db::collections::MilestoneCollection,
+    types::stardust::{block::payload::MilestoneId, util::payload::milestone::get_test_milestone_payload},
+};
 use common::connect_to_test_db;
 
 #[tokio::test]
 async fn test_milestones() {
     let db = connect_to_test_db("test-milestones").await.unwrap();
     db.clear().await.unwrap();
-    db.create_milestone_indexes().await.unwrap();
+    let collection = db.collection::<MilestoneCollection>();
+    collection.create_indexes().await.unwrap();
 
     let milestone = get_test_milestone_payload();
     let milestone_id = MilestoneId::from(
@@ -20,27 +24,33 @@ async fn test_milestones() {
             .id(),
     );
 
-    db.insert_milestone(
-        milestone_id,
-        milestone.essence.index,
-        milestone.essence.timestamp.into(),
-        milestone.clone(),
-    )
-    .await
-    .unwrap();
+    collection
+        .insert_milestone(
+            milestone_id,
+            milestone.essence.index,
+            milestone.essence.timestamp.into(),
+            milestone.clone(),
+        )
+        .await
+        .unwrap();
 
     assert_eq!(
-        db.get_milestone_id(milestone.essence.index).await.unwrap(),
+        collection.get_milestone_id(milestone.essence.index).await.unwrap(),
         Some(milestone_id),
     );
 
     assert_eq!(
-        db.get_milestone_payload_by_id(&milestone_id).await.unwrap().as_ref(),
+        collection
+            .get_milestone_payload_by_id(&milestone_id)
+            .await
+            .unwrap()
+            .as_ref(),
         Some(&milestone)
     );
 
     assert_eq!(
-        db.get_milestone_payload(milestone.essence.index)
+        collection
+            .get_milestone_payload(milestone.essence.index)
             .await
             .unwrap()
             .as_ref(),


### PR DESCRIPTION
This PR creates individual types for each DB collection. In order to make it as clean as possible, I created a new API trait `MongoDbCollection` to enable calling genericised functions and convert the underlying collection types.

These collections have a small quirk: Some of their methods need to access more than one collection. For this reason, some of them hold multiple mongodb `Collections`. There is probably a better way to do this.

Additionally, I added a thread-safe version of the chunks iterator from `itertools` which mostly works. Sometimes it causes inexplicable errors in the wrong locations, but I believe these are actually compiler bugs and not real issues. Either way, there is only one location where it was necessary to work around this: inserting treasury payloads.

I have observed a significant improvement in syncing times with these changes, due to the reduction of cloning.