### PR TITLE
fix(config): override mongodb `connect_url` (and not the config) when given as CLI arg

### DIFF
--- a/src/bin/inx-chronicle/config.rs
+++ b/src/bin/inx-chronicle/config.rs
@@ -41,10 +41,7 @@ impl ChronicleConfig {
     /// Applies command line arguments to the config.
     pub fn apply_cl_args(&mut self, args: &super::cli::ClArgs) {
         if let Some(connect_url) = &args.db_addr {
-            self.mongodb = MongoDbConfig {
-                connect_url: connect_url.clone(),
-                ..Default::default()
-            };
+            self.mongodb.connect_url = connect_url.clone();
         }
         #[cfg(all(feature = "stardust", feature = "inx"))]
         {


### PR DESCRIPTION
Fixes #629