### PR TITLE
docs(wiki): change Chronicle path to be compatible with other versions

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -7,7 +7,7 @@ module.exports = {
       {
         id: 'inx-chronicle-develop',
         path: path.resolve(__dirname, 'docs'),
-        routeBasePath: 'inx-chronicle',
+        routeBasePath: 'chronicle',
         sidebarPath: path.resolve(__dirname, 'sidebars.js'),
         editUrl: 'https://github.com/iotaledger/inx-chronicle/edit/main/documentation',
         remarkPlugins: [require('remark-code-import'), require('remark-import-partial')],


### PR DESCRIPTION
We need to use the same subpath in all versions so that the wiki can determine the existing versions