### PR TITLE
doc(wiki): remove version info

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -5,19 +5,12 @@ module.exports = {
     [
       '@docusaurus/plugin-content-docs',
       {
-        id: 'inx-chronicle-develop',
+        id: 'inx-chronicle',
         path: path.resolve(__dirname, 'docs'),
         routeBasePath: 'chronicle',
         sidebarPath: path.resolve(__dirname, 'sidebars.js'),
         editUrl: 'https://github.com/iotaledger/inx-chronicle/edit/main/documentation',
         remarkPlugins: [require('remark-code-import'), require('remark-import-partial')],
-        versions: {
-          current: {
-              label: 'Develop',
-              path: 'develop',
-              badge: true
-          },
-        },
       }
     ],
   ],


### PR DESCRIPTION
With wiki V3 we can get rid of this. Chronicle docs for Shimmer will be hosted under /shimmer/chronicle/...