### PR TITLE
fix(types): conditionally import `context`

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "stardust")]
 pub mod context;
 #[cfg(feature = "stardust")]
 pub mod ledger;


### PR DESCRIPTION
This should fix the broken canary build again.