### PR TITLE
fix(analytics)!: correctly count aliases and NFT activity

### DIFF
--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -546,7 +546,7 @@ mod analytics {
                                     "$and": [
                                         { "output.alias_id": { "$exists": true } },
                                         { "output.alias_id": { "$ne": AliasId::implicit() } },
-                                    ] 
+                                    ]
                                 } },
                                 // Group by state indexes to find where it changed
                                 { "$group": {

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -514,7 +514,12 @@ mod analytics {
                                 } },
                             ],
                             "nft_changed": [
-                                { "$match": { "output.nft_id": { "$ne": NftId::implicit() } } },
+                                { "$match": { 
+                                    "$and": [
+                                        { "output.nft_id": { "$exists": true } },
+                                        { "output.nft_id": { "$ne": NftId::implicit() } },
+                                    ]
+                                } },
                                 { "$group": {
                                     "_id": "$output.nft_id",
                                     "transferred": { "$sum": { "$cond": [ { "$eq": [ "$metadata.booked.milestone_index", index ] }, 1, 0 ] } },
@@ -537,7 +542,12 @@ mod analytics {
                                 } },
                             ],
                             "alias_changed": [
-                                { "$match": { "output.alias_id": { "$ne": AliasId::implicit() } } },
+                                { "$match": {
+                                    "$and": [
+                                        { "output.alias_id": { "$exists": true } },
+                                        { "output.alias_id": { "$ne": AliasId::implicit() } },
+                                    ] 
+                                } },
                                 // Group by state indexes to find where it changed
                                 { "$group": {
                                     "_id": { "alias_id": "$output.alias_id", "state_index": "$output.state_index" },


### PR DESCRIPTION
This is a hotfix taken from #924. This fixes a problem with miscounted changed aliases and NFTs in our analytics.

## Notes to Reviewer

<!--
The following are examples of particular points that you would like reviewers to pay attention to. Add or remove
items as appropriate for this PR.
-->

As a reviewer, please pay particular attention to the following areas when reviewing this PR and tick the above boxes after you have completed the steps.

#### Database Changes
* [x] Review database queries for correctness/conciseness.
* [x] Ensure queries are supported by indexes if needed.
* [x] Check for breaking changes in the data model and matching (conventional) commit message prefix.
