### PR TITLE
fix(analytics): computation of daily active addresses

### DIFF
--- a/src/bin/inx-chronicle/stardust_inx/mod.rs
+++ b/src/bin/inx-chronicle/stardust_inx/mod.rs
@@ -71,7 +71,11 @@ pub async fn gather_analytics(
         analytics.push(res.unwrap()?);
     }
 
-    debug_assert_eq!(len_before, analytics.len(), "The number of analytics should never change.");
+    debug_assert_eq!(
+        len_before,
+        analytics.len(),
+        "The number of analytics should never change."
+    );
 
     Ok(())
 }

--- a/src/bin/inx-chronicle/stardust_inx/mod.rs
+++ b/src/bin/inx-chronicle/stardust_inx/mod.rs
@@ -117,13 +117,16 @@ impl InxWorker {
 
         debug!("Started listening to ledger updates via INX.");
 
+        #[cfg(feature = "analytics")]
+        let mut analytics = chronicle::db::collections::analytics::all_analytics();
+
         while let Some(ledger_update) = stream.try_next().await? {
             self.handle_ledger_update(
                 &mut inx,
                 ledger_update,
                 &mut stream,
                 #[cfg(feature = "analytics")]
-                &mut chronicle::db::collections::analytics::all_analytics(),
+                &mut analytics,
             )
             .await?;
         }

--- a/src/bin/inx-chronicle/stardust_inx/mod.rs
+++ b/src/bin/inx-chronicle/stardust_inx/mod.rs
@@ -49,6 +49,8 @@ pub async fn gather_analytics(
 ) -> Result<(), InxWorkerError> {
     let mut tasks = JoinSet::new();
 
+    let len_before = analytics.len();
+
     for analytic in analytics.drain(..) {
         let mongodb = mongodb.clone();
         let influxdb = influxdb.clone();
@@ -68,6 +70,8 @@ pub async fn gather_analytics(
         // Panic: Acceptable risk
         analytics.push(res.unwrap()?);
     }
+
+    debug_assert_eq!(len_before, analytics.len(), "The number of analytics should never change.");
 
     Ok(())
 }


### PR DESCRIPTION
Daily active addresses were not computed because we recreated the `Vec` of analytics for each ledger update, leading to a reset of `current_date`.

## Notes to Reviewer

<!--
The following are examples of particular points that you would like reviewers to pay attention to. Add or remove
items as appropriate for this PR.
-->

As a reviewer, please pay particular attention to the following areas when reviewing this PR and tick the above boxes after you have completed the steps.

#### INX Changes
* [ ] Run chronicle using an INX connection.