### PR TITLE
chore(clippy): fix `Display` formatting

### DIFF
--- a/src/inx/raw.rs
+++ b/src/inx/raw.rs
@@ -26,14 +26,14 @@ impl<T: Packable> RawMessage<T> {
     /// [`ProtocolParameters`](iota_types::block::protocol::ProtocolParameters) to verify the bytes.
     pub fn inner(self, visitor: &T::UnpackVisitor) -> Result<T, InxError> {
         let unpacked =
-            T::unpack_verified(self.data, visitor).map_err(|e| InxError::InvalidRawBytes(format!("{:?}", e)))?;
+            T::unpack_verified(self.data, visitor).map_err(|e| InxError::InvalidRawBytes(format!("{e:?}")))?;
         Ok(unpacked)
     }
 
     /// Unpack the raw data into a type `T` without performing syntactic or semantic validation. This is useful if the
     /// type is guaranteed to be well-formed, for example when it was transmitted via the INX interface.
     pub fn inner_unverified(self) -> Result<T, InxError> {
-        let unpacked = T::unpack_unverified(self.data).map_err(|e| InxError::InvalidRawBytes(format!("{:?}", e)))?;
+        let unpacked = T::unpack_unverified(self.data).map_err(|e| InxError::InvalidRawBytes(format!("{e:?}")))?;
         Ok(unpacked)
     }
 }

--- a/src/types/ledger/output_metadata.rs
+++ b/src/types/ledger/output_metadata.rs
@@ -96,7 +96,7 @@ mod inx {
         fn try_from(value: ::inx::proto::LedgerOutput) -> Result<Self, Self::Error> {
             let data = maybe_missing!(value.output).data;
             let bee_output = iota_types::block::output::Output::unpack_unverified(data)
-                .map_err(|e| InxError::InvalidRawBytes(format!("{:?}", e)))?;
+                .map_err(|e| InxError::InvalidRawBytes(format!("{e:?}")))?;
 
             Ok(Self {
                 rent_structure: compute_rent_structure(&bee_output),


### PR DESCRIPTION
This is to satisfy future versions of `clippy`.