### PR TITLE
fix(ci): fix `format` arguments

### DIFF
--- a/src/bin/inx-chronicle/api/error.rs
+++ b/src/bin/inx-chronicle/api/error.rs
@@ -222,7 +222,7 @@ impl IntoResponse for ErrorBody {
                 .unwrap(),
             Err(e) => {
                 error!("Unable to serialize error body: {}", e);
-                Result::<(), _>::Err(format!("Unable to serialize error body: {}", e)).into_response()
+                Result::<(), _>::Err(format!("Unable to serialize error body: {e}")).into_response()
             }
         }
     }

--- a/src/bin/inx-chronicle/api/routes.rs
+++ b/src/bin/inx-chronicle/api/routes.rs
@@ -78,7 +78,7 @@ async fn login(
             config.jwt_secret_key.as_ref(),
         )?;
 
-        Ok(format!("Bearer {}", jwt))
+        Ok(format!("Bearer {jwt}"))
     } else {
         Err(ApiError::from(AuthError::IncorrectPassword))
     }


### PR DESCRIPTION
This should fix our canary CI pipeline.