### PR TITLE
fix(analytics): fill daily analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"

--- a/docker/assets/grafana/dashboards/analytics_dashboard.json
+++ b/docker/assets/grafana/dashboards/analytics_dashboard.json
@@ -3191,7 +3191,7 @@
           "tags": []
         }
       ],
-      "title": "Transaction distribution by Consumed Outputs /${aggregation_interval}",
+      "title": "Transaction Distribution by Consumed Outputs /${aggregation_interval}",
       "type": "timeseries"
     },
     {
@@ -3502,7 +3502,7 @@
           "tags": []
         }
       ],
-      "title": "Transaction distribution by Created Outputs /${aggregation_interval}",
+      "title": "Transaction Distribution by Created Outputs /${aggregation_interval}",
       "type": "timeseries"
     },
     {

--- a/src/analytics/influx.rs
+++ b/src/analytics/influx.rs
@@ -129,12 +129,22 @@ impl Measurement for TransactionSizeMeasurement {
     const NAME: &'static str = "stardust_transaction_size_distribution";
 
     fn add_fields(&self, mut query: WriteQuery) -> WriteQuery {
-        for (bucket, value) in self.input_buckets.iter() {
-            query = query.add_field(format!("input_{}", bucket), *value as u64);
+        for (bucket, value) in self.input_buckets.single.iter().enumerate() {
+            query = query.add_field(format!("input_{}", bucket + 1), *value as u64);
         }
-        for (bucket, value) in self.output_buckets.iter() {
-            query = query.add_field(format!("output_{}", bucket), *value as u64);
+        query = query
+            .add_field("input_small", self.input_buckets.small as u64)
+            .add_field("input_medium", self.input_buckets.medium as u64)
+            .add_field("input_large", self.input_buckets.large as u64)
+            .add_field("input_huge", self.input_buckets.huge as u64);
+        for (bucket, value) in self.output_buckets.single.iter().enumerate() {
+            query = query.add_field(format!("output_{}", bucket + 1), *value as u64);
         }
+        query = query
+            .add_field("output_small", self.output_buckets.small as u64)
+            .add_field("output_medium", self.output_buckets.medium as u64)
+            .add_field("output_large", self.output_buckets.large as u64)
+            .add_field("output_huge", self.output_buckets.huge as u64);
         query
     }
 }

--- a/src/analytics/influx.rs
+++ b/src/analytics/influx.rs
@@ -65,7 +65,7 @@ where
     M: IntervalMeasurement,
 {
     fn prepare_query(&self) -> WriteQuery {
-        influxdb::Timestamp::Seconds(self.date.midnight().assume_utc().unix_timestamp() as _)
+        influxdb::Timestamp::Seconds(self.start_date.midnight().assume_utc().unix_timestamp() as _)
             .into_query(M::name(self.interval))
             .add_fields(&self.inner)
     }

--- a/src/analytics/ledger/active_addresses.rs
+++ b/src/analytics/ledger/active_addresses.rs
@@ -28,13 +28,13 @@ impl IntervalAnalytics for AddressActivityMeasurement {
 
     async fn handle_date_range(
         &mut self,
-        start: time::Date,
+        start_date: time::Date,
         interval: AnalyticsInterval,
         db: &MongoDb,
     ) -> eyre::Result<Self::Measurement> {
         let count = db
             .collection::<OutputCollection>()
-            .get_address_activity_count_in_range(start, interval.end_date(&start))
+            .get_address_activity_count_in_range(start_date, interval.end_date(&start_date))
             .await?;
         Ok(AddressActivityMeasurement { count })
     }

--- a/src/analytics/ledger/active_addresses.rs
+++ b/src/analytics/ledger/active_addresses.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use super::*;
 use crate::{
-    analytics::DailyAnalytics,
+    analytics::{AnalyticsInterval, IntervalAnalytics},
     db::{collections::OutputCollection, MongoDb},
     types::stardust::block::Address,
 };
@@ -22,21 +22,21 @@ pub(crate) struct AddressActivityAnalytics {
     addresses: HashSet<Address>,
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct DailyAddressActivityMeasurement {
-    pub(crate) count: usize,
-}
-
 #[async_trait::async_trait]
-impl DailyAnalytics for DailyAddressActivityMeasurement {
+impl IntervalAnalytics for AddressActivityMeasurement {
     type Measurement = Self;
 
-    async fn handle_date(&mut self, date: time::Date, db: &MongoDb) -> eyre::Result<Self::Measurement> {
+    async fn handle_date_range(
+        &mut self,
+        start: time::Date,
+        interval: AnalyticsInterval,
+        db: &MongoDb,
+    ) -> eyre::Result<Self::Measurement> {
         let count = db
             .collection::<OutputCollection>()
-            .get_address_activity_count(date)
+            .get_address_activity_count_in_range(start, interval.end_date(&start))
             .await?;
-        Ok(DailyAddressActivityMeasurement { count })
+        Ok(AddressActivityMeasurement { count })
     }
 }
 

--- a/src/analytics/ledger/active_addresses.rs
+++ b/src/analytics/ledger/active_addresses.rs
@@ -3,65 +3,48 @@
 
 use std::collections::HashSet;
 
-use time::{Duration, OffsetDateTime};
-
 use super::*;
-use crate::types::stardust::block::Address;
+use crate::{
+    analytics::DailyAnalytics,
+    db::{collections::OutputCollection, MongoDb},
+    types::stardust::block::Address,
+};
 
+#[derive(Debug, Default)]
 pub(crate) struct AddressActivityMeasurement {
     pub(crate) count: usize,
 }
 
 /// Computes the number of addresses that were active during a given time interval.
 #[allow(missing_docs)]
+#[derive(Debug, Default)]
 pub(crate) struct AddressActivityAnalytics {
-    start_time: OffsetDateTime,
-    interval: Duration,
     addresses: HashSet<Address>,
-    // Unfortunately, I don't see another way of implementing it using our current trait design
-    measurement: Option<AddressActivityMeasurement>,
 }
 
-impl AddressActivityAnalytics {
-    /// Initialize the analytics by reading the current ledger state.
-    pub(crate) fn init<'a>(
-        start_time: OffsetDateTime,
-        interval: Duration,
-        unspent_outputs: impl IntoIterator<Item = &'a LedgerOutput>,
-    ) -> Self {
-        let addresses = unspent_outputs
-            .into_iter()
-            .filter_map(|output| {
-                let booked = OffsetDateTime::try_from(output.booked.milestone_timestamp).unwrap();
-                if (start_time <= booked) && (booked < start_time + interval) {
-                    output.owning_address().cloned()
-                } else {
-                    None
-                }
-            })
-            .collect();
-        Self {
-            start_time,
-            interval,
-            addresses,
-            measurement: None,
-        }
+#[async_trait::async_trait]
+impl DailyAnalytics for AddressActivityMeasurement {
+    type Measurement = TimeInterval<Self>;
+
+    async fn handle_date(&mut self, date: time::Date, db: &MongoDb) -> eyre::Result<Self::Measurement> {
+        let count = db
+            .collection::<OutputCollection>()
+            .get_address_activity_count(date)
+            .await?;
+        let from = date.midnight().assume_utc();
+        Ok(TimeInterval {
+            from,
+            to_exclusive: from + time::Duration::days(1),
+            inner: AddressActivityMeasurement { count },
+        })
     }
 }
 
 impl Analytics for AddressActivityAnalytics {
-    type Measurement = TimeInterval<AddressActivityMeasurement>;
+    type Measurement = PerMilestone<AddressActivityMeasurement>;
 
-    fn begin_milestone(&mut self, ctx: &dyn AnalyticsContext) {
-        let end = self.start_time + self.interval;
-        // Panic: The milestone timestamp is guaranteed to be valid.
-        if OffsetDateTime::try_from(ctx.at().milestone_timestamp).unwrap() > end {
-            self.measurement = Some(AddressActivityMeasurement {
-                count: self.addresses.len(),
-            });
-            self.addresses.clear();
-            self.start_time = end;
-        }
+    fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {
+        *self = Self::default();
     }
 
     fn handle_transaction(&mut self, consumed: &[LedgerSpent], created: &[LedgerOutput], _ctx: &dyn AnalyticsContext) {
@@ -78,11 +61,12 @@ impl Analytics for AddressActivityAnalytics {
         }
     }
 
-    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        self.measurement.take().map(|m| TimeInterval {
-            from: self.start_time,
-            to_exclusive: self.start_time + self.interval,
-            inner: m,
+    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(PerMilestone {
+            at: *ctx.at(),
+            inner: AddressActivityMeasurement {
+                count: self.addresses.len(),
+            },
         })
     }
 }

--- a/src/analytics/ledger/address_balance.rs
+++ b/src/analytics/ledger/address_balance.rs
@@ -39,7 +39,7 @@ impl AddressBalancesAnalytics {
 }
 
 impl Analytics for AddressBalancesAnalytics {
-    type Measurement = PerMilestone<AddressBalanceMeasurement>;
+    type Measurement = AddressBalanceMeasurement;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {}
 
@@ -74,12 +74,9 @@ impl Analytics for AddressBalancesAnalytics {
             token_distribution[index].address_count += 1;
             token_distribution[index].total_amount += *amount;
         }
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: AddressBalanceMeasurement {
-                address_with_balance_count: self.balances.len(),
-                token_distribution,
-            },
+        Some(AddressBalanceMeasurement {
+            address_with_balance_count: self.balances.len(),
+            token_distribution,
         })
     }
 }

--- a/src/analytics/ledger/base_token.rs
+++ b/src/analytics/ledger/base_token.rs
@@ -16,7 +16,7 @@ pub(crate) struct BaseTokenActivityMeasurement {
 }
 
 impl Analytics for BaseTokenActivityMeasurement {
-    type Measurement = PerMilestone<Self>;
+    type Measurement = Self;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {
         *self = Default::default();
@@ -47,10 +47,7 @@ impl Analytics for BaseTokenActivityMeasurement {
         self.transferred_amount = TokenAmount(balance_deltas.values().copied().map(|d| d.max(0) as u64).sum());
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: *self,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(*self)
     }
 }

--- a/src/analytics/ledger/ledger_outputs.rs
+++ b/src/analytics/ledger/ledger_outputs.rs
@@ -48,7 +48,7 @@ impl LedgerOutputMeasurement {
 }
 
 impl Analytics for LedgerOutputMeasurement {
-    type Measurement = PerMilestone<Self>;
+    type Measurement = Self;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {}
 
@@ -60,10 +60,7 @@ impl Analytics for LedgerOutputMeasurement {
         self.wrapping_add(created);
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: *self,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(*self)
     }
 }

--- a/src/analytics/ledger/ledger_size.rs
+++ b/src/analytics/ledger/ledger_size.rs
@@ -85,7 +85,7 @@ impl LedgerSizeAnalytics {
 }
 
 impl Analytics for LedgerSizeAnalytics {
-    type Measurement = PerMilestone<LedgerSizeMeasurement>;
+    type Measurement = LedgerSizeMeasurement;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {}
 
@@ -100,10 +100,7 @@ impl Analytics for LedgerSizeAnalytics {
         }
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: self.measurement,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(self.measurement)
     }
 }

--- a/src/analytics/ledger/mod.rs
+++ b/src/analytics/ledger/mod.rs
@@ -4,7 +4,7 @@
 //! Statistics about the ledger.
 
 pub(super) use self::{
-    active_addresses::{AddressActivityAnalytics, AddressActivityMeasurement},
+    active_addresses::{AddressActivityAnalytics, AddressActivityMeasurement, DailyAddressActivityMeasurement},
     address_balance::{AddressBalanceMeasurement, AddressBalancesAnalytics},
     base_token::BaseTokenActivityMeasurement,
     ledger_outputs::LedgerOutputMeasurement,
@@ -15,7 +15,7 @@ pub(super) use self::{
     unlock_conditions::UnlockConditionMeasurement,
 };
 use crate::{
-    analytics::{Analytics, AnalyticsContext, PerMilestone, TimeInterval},
+    analytics::{Analytics, AnalyticsContext},
     types::{
         ledger::{LedgerOutput, LedgerSpent},
         stardust::block::{output::TokenAmount, Output},
@@ -164,10 +164,9 @@ mod test {
             unclaimed_tokens.begin_milestone(&ctx);
             unclaimed_tokens.handle_transaction(&[consumed], &[created], &ctx);
             let unclaimed_tokens_measurement = unclaimed_tokens.end_milestone(&ctx).unwrap();
-            assert_eq!(unclaimed_tokens_measurement.at, ctx.at);
-            assert_eq!(unclaimed_tokens_measurement.inner.unclaimed_count, 5 - i - 1);
+            assert_eq!(unclaimed_tokens_measurement.unclaimed_count, 5 - i - 1);
             assert_eq!(
-                unclaimed_tokens_measurement.inner.unclaimed_value.0,
+                unclaimed_tokens_measurement.unclaimed_value.0,
                 (1..=5).sum::<u64>() - (1..=(i as u64 + 1)).sum::<u64>()
             )
         }
@@ -272,11 +271,10 @@ mod test {
         output_activity.handle_transaction(&consumed, &created, &ctx);
         let output_activity_measurement = output_activity.end_milestone(&ctx).unwrap();
 
-        assert_eq!(output_activity_measurement.at, ctx.at);
-        assert_eq!(output_activity_measurement.inner.alias.created_count, 1);
-        assert_eq!(output_activity_measurement.inner.alias.governor_changed_count, 1);
-        assert_eq!(output_activity_measurement.inner.alias.state_changed_count, 1);
-        assert_eq!(output_activity_measurement.inner.alias.destroyed_count, 1);
+        assert_eq!(output_activity_measurement.alias.created_count, 1);
+        assert_eq!(output_activity_measurement.alias.governor_changed_count, 1);
+        assert_eq!(output_activity_measurement.alias.state_changed_count, 1);
+        assert_eq!(output_activity_measurement.alias.destroyed_count, 1);
     }
 
     #[test]
@@ -364,10 +362,9 @@ mod test {
         output_activity.handle_transaction(&consumed, &created, &ctx);
         let output_activity_measurement = output_activity.end_milestone(&ctx).unwrap();
 
-        assert_eq!(output_activity_measurement.at, ctx.at);
-        assert_eq!(output_activity_measurement.inner.nft.created_count, 1);
-        assert_eq!(output_activity_measurement.inner.nft.transferred_count, 2);
-        assert_eq!(output_activity_measurement.inner.nft.destroyed_count, 2);
+        assert_eq!(output_activity_measurement.nft.created_count, 1);
+        assert_eq!(output_activity_measurement.nft.transferred_count, 2);
+        assert_eq!(output_activity_measurement.nft.destroyed_count, 2);
 
         let mut created_nft = NftOutput::rand(&protocol_params);
         created_nft.nft_id = NftId::implicit();
@@ -402,10 +399,9 @@ mod test {
         output_activity.handle_transaction(&[], &created, &ctx);
         let output_activity_measurement = output_activity.end_milestone(&ctx).unwrap();
 
-        assert_eq!(output_activity_measurement.at, ctx.at);
-        assert_eq!(output_activity_measurement.inner.nft.created_count, 1);
-        assert_eq!(output_activity_measurement.inner.nft.transferred_count, 0);
-        assert_eq!(output_activity_measurement.inner.nft.destroyed_count, 0);
+        assert_eq!(output_activity_measurement.nft.created_count, 1);
+        assert_eq!(output_activity_measurement.nft.transferred_count, 0);
+        assert_eq!(output_activity_measurement.nft.destroyed_count, 0);
 
         // Created on milestone 2
         let created = [
@@ -437,10 +433,9 @@ mod test {
         output_activity.handle_transaction(&consumed, &created, &ctx);
         let output_activity_measurement = output_activity.end_milestone(&ctx).unwrap();
 
-        assert_eq!(output_activity_measurement.at, ctx.at);
-        assert_eq!(output_activity_measurement.inner.nft.created_count, 0);
-        assert_eq!(output_activity_measurement.inner.nft.transferred_count, 3);
-        assert_eq!(output_activity_measurement.inner.nft.destroyed_count, 0);
+        assert_eq!(output_activity_measurement.nft.created_count, 0);
+        assert_eq!(output_activity_measurement.nft.transferred_count, 3);
+        assert_eq!(output_activity_measurement.nft.destroyed_count, 0);
     }
 
     fn rand_output_with_address_and_value(
@@ -541,9 +536,8 @@ mod test {
         base_tokens.handle_transaction(&consumed, &created, &ctx);
         let base_tokens_measurement = base_tokens.end_milestone(&ctx).unwrap();
 
-        assert_eq!(base_tokens_measurement.at, ctx.at);
-        assert_eq!(base_tokens_measurement.inner.booked_amount.0, 460);
+        assert_eq!(base_tokens_measurement.booked_amount.0, 460);
         // Address 1 has delta +175, Address 2 has delta +70, Address 3 has delta -255
-        assert_eq!(base_tokens_measurement.inner.transferred_amount.0, 245)
+        assert_eq!(base_tokens_measurement.transferred_amount.0, 245)
     }
 }

--- a/src/analytics/ledger/mod.rs
+++ b/src/analytics/ledger/mod.rs
@@ -4,7 +4,7 @@
 //! Statistics about the ledger.
 
 pub(super) use self::{
-    active_addresses::{AddressActivityAnalytics, AddressActivityMeasurement, DailyAddressActivityMeasurement},
+    active_addresses::{AddressActivityAnalytics, AddressActivityMeasurement},
     address_balance::{AddressBalanceMeasurement, AddressBalancesAnalytics},
     base_token::BaseTokenActivityMeasurement,
     ledger_outputs::LedgerOutputMeasurement,

--- a/src/analytics/ledger/output_activity.rs
+++ b/src/analytics/ledger/output_activity.rs
@@ -18,7 +18,7 @@ pub(crate) struct OutputActivityMeasurement {
 }
 
 impl Analytics for OutputActivityMeasurement {
-    type Measurement = PerMilestone<Self>;
+    type Measurement = Self;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {
         *self = Self::default();
@@ -30,11 +30,8 @@ impl Analytics for OutputActivityMeasurement {
         self.foundry.handle_transaction(consumed, created);
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: *self,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(*self)
     }
 }
 

--- a/src/analytics/ledger/transaction_size.rs
+++ b/src/analytics/ledger/transaction_size.rs
@@ -1,75 +1,49 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(missing_docs)]
-
-use std::{collections::HashMap, fmt::Display};
-
 use super::*;
 
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub(crate) enum SizeBucket {
-    Single(usize), // 1,..7
-    Small,         // [8..16)
-    Medium,        // [16..32)
-    Large,         // [32..64)
-    Huge,          // [64..128)
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct TransactionSizeBuckets {
+    pub(crate) single: [usize; 7], // 1,..,7
+    pub(crate) small: usize,       // [8..16)
+    pub(crate) medium: usize,      // [16..32)
+    pub(crate) large: usize,       // [32..64)
+    pub(crate) huge: usize,        // [64..128)
 }
 
-impl From<usize> for SizeBucket {
-    fn from(value: usize) -> Self {
+impl TransactionSizeBuckets {
+    fn add(&mut self, value: usize) {
         match value {
             0 => unreachable!("invalid transaction"),
-            1..=7 => SizeBucket::Single(value),
-            8..=15 => SizeBucket::Small,
-            16..=31 => SizeBucket::Medium,
-            32..=63 => SizeBucket::Large,
-            _ => SizeBucket::Huge,
+            1..=7 => self.single[value - 1] += 1,
+            8..=15 => self.small += 1,
+            16..=31 => self.medium += 1,
+            32..=63 => self.large += 1,
+            _ => self.huge += 1,
         }
     }
 }
 
-impl Display for SizeBucket {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SizeBucket::Single(v) => write!(f, "{}", v),
-            SizeBucket::Small => write!(f, "small"),
-            SizeBucket::Medium => write!(f, "medium"),
-            SizeBucket::Large => write!(f, "large"),
-            SizeBucket::Huge => write!(f, "huge"),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct TransactionSizeMeasurement {
-    pub(crate) input_buckets: HashMap<SizeBucket, usize>,
-    pub(crate) output_buckets: HashMap<SizeBucket, usize>,
+    pub(crate) input_buckets: TransactionSizeBuckets,
+    pub(crate) output_buckets: TransactionSizeBuckets,
 }
 
 impl Analytics for TransactionSizeMeasurement {
     type Measurement = TransactionSizeMeasurement;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {
-        let mut buckets = HashMap::from([
-            (SizeBucket::Small, 0),
-            (SizeBucket::Medium, 0),
-            (SizeBucket::Large, 0),
-            (SizeBucket::Huge, 0),
-        ]);
-        for i in 0..8 {
-            buckets.insert(SizeBucket::Single(i), 0);
-        }
-        self.input_buckets = buckets.clone();
-        self.output_buckets = buckets;
+        *self = Default::default()
     }
 
     fn handle_transaction(&mut self, consumed: &[LedgerSpent], created: &[LedgerOutput], _ctx: &dyn AnalyticsContext) {
-        *self.input_buckets.entry(consumed.len().into()).or_default() += 1;
-        *self.output_buckets.entry(created.len().into()).or_default() += 1;
+        self.input_buckets.add(consumed.len());
+        self.output_buckets.add(created.len());
     }
 
     fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(std::mem::take(self))
+        Some(*self)
     }
 }

--- a/src/analytics/ledger/transaction_size.rs
+++ b/src/analytics/ledger/transaction_size.rs
@@ -47,7 +47,7 @@ pub(crate) struct TransactionSizeMeasurement {
 }
 
 impl Analytics for TransactionSizeMeasurement {
-    type Measurement = PerMilestone<TransactionSizeMeasurement>;
+    type Measurement = TransactionSizeMeasurement;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {
         let mut buckets = HashMap::from([
@@ -68,10 +68,7 @@ impl Analytics for TransactionSizeMeasurement {
         *self.output_buckets.entry(created.len().into()).or_default() += 1;
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: self.clone(),
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(std::mem::take(self))
     }
 }

--- a/src/analytics/ledger/unclaimed_tokens.rs
+++ b/src/analytics/ledger/unclaimed_tokens.rs
@@ -27,7 +27,7 @@ impl UnclaimedTokenMeasurement {
 }
 
 impl Analytics for UnclaimedTokenMeasurement {
-    type Measurement = PerMilestone<Self>;
+    type Measurement = Self;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {}
 
@@ -40,10 +40,7 @@ impl Analytics for UnclaimedTokenMeasurement {
         }
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: *self,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(*self)
     }
 }

--- a/src/analytics/ledger/unlock_conditions.rs
+++ b/src/analytics/ledger/unlock_conditions.rs
@@ -70,7 +70,7 @@ impl UnlockConditionMeasurement {
 }
 
 impl Analytics for UnlockConditionMeasurement {
-    type Measurement = PerMilestone<Self>;
+    type Measurement = Self;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {}
 
@@ -82,10 +82,7 @@ impl Analytics for UnlockConditionMeasurement {
         self.wrapping_sub(consumed);
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: *self,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(*self)
     }
 }

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -102,7 +102,7 @@ trait IntervalAnalytics {
     type Measurement;
     async fn handle_date_range(
         &mut self,
-        start: time::Date,
+        start_date: time::Date,
         interval: AnalyticsInterval,
         db: &MongoDb,
     ) -> eyre::Result<Self::Measurement>;
@@ -113,7 +113,7 @@ trait IntervalAnalytics {
 trait DynIntervalAnalytics: Send {
     async fn handle_date_range(
         &mut self,
-        start: time::Date,
+        start_date: time::Date,
         interval: AnalyticsInterval,
         db: &MongoDb,
     ) -> eyre::Result<Box<dyn PrepareQuery>>;
@@ -126,15 +126,15 @@ where
 {
     async fn handle_date_range(
         &mut self,
-        start: time::Date,
+        start_date: time::Date,
         interval: AnalyticsInterval,
         db: &MongoDb,
     ) -> eyre::Result<Box<dyn PrepareQuery>> {
-        IntervalAnalytics::handle_date_range(self, start, interval, db)
+        IntervalAnalytics::handle_date_range(self, start_date, interval, db)
             .await
             .map(|r| {
                 Box::new(PerInterval {
-                    date: start,
+                    start_date,
                     interval,
                     inner: r,
                 }) as _
@@ -355,7 +355,7 @@ struct PerMilestone<M> {
 #[derive(Clone, Debug)]
 #[allow(missing_docs)]
 struct PerInterval<M> {
-    date: time::Date,
+    start_date: time::Date,
     interval: AnalyticsInterval,
     inner: M,
 }

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -49,7 +49,6 @@ impl<'a, I: InputSource> AnalyticsContext for Milestone<'a, I> {
     }
 }
 
-#[allow(missing_docs)]
 trait Analytics {
     type Measurement;
     fn begin_milestone(&mut self, ctx: &dyn AnalyticsContext);
@@ -98,7 +97,6 @@ where
     }
 }
 
-#[allow(missing_docs)]
 #[async_trait::async_trait]
 trait DailyAnalytics {
     type Measurement;

--- a/src/analytics/tangle/block_activity.rs
+++ b/src/analytics/tangle/block_activity.rs
@@ -18,7 +18,7 @@ pub(crate) struct BlockActivityMeasurement {
 }
 
 impl Analytics for BlockActivityMeasurement {
-    type Measurement = PerMilestone<Self>;
+    type Measurement = Self;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {
         *self = Default::default();
@@ -39,10 +39,7 @@ impl Analytics for BlockActivityMeasurement {
         }
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: *self,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(*self)
     }
 }

--- a/src/analytics/tangle/milestone_size.rs
+++ b/src/analytics/tangle/milestone_size.rs
@@ -14,7 +14,7 @@ pub(crate) struct MilestoneSizeMeasurement {
 }
 
 impl Analytics for MilestoneSizeMeasurement {
-    type Measurement = PerMilestone<Self>;
+    type Measurement = Self;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {
         *self = Self::default();
@@ -33,10 +33,7 @@ impl Analytics for MilestoneSizeMeasurement {
         }
     }
 
-    fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
-        Some(PerMilestone {
-            at: *ctx.at(),
-            inner: *self,
-        })
+    fn end_milestone(&mut self, _ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
+        Some(*self)
     }
 }

--- a/src/analytics/tangle/mod.rs
+++ b/src/analytics/tangle/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use self::{
     protocol_params::ProtocolParamsMeasurement,
 };
 use crate::{
-    analytics::{Analytics, AnalyticsContext, PerMilestone},
+    analytics::{Analytics, AnalyticsContext},
     tangle::BlockData,
     types::{stardust::block::Payload, tangle::ProtocolParameters},
 };
@@ -89,26 +89,19 @@ mod test {
         let block_activity_measurement = block_activity.end_milestone(&ctx).unwrap();
         let milestone_size_measurement = milestone_size.end_milestone(&ctx).unwrap();
 
-        assert_eq!(block_activity_measurement.at, ctx.at);
-        assert_eq!(block_activity_measurement.inner.transaction_count, 1);
-        assert_eq!(block_activity_measurement.inner.treasury_transaction_count, 1);
-        assert_eq!(block_activity_measurement.inner.milestone_count, 1);
-        assert_eq!(block_activity_measurement.inner.tagged_data_count, 1);
-        assert_eq!(block_activity_measurement.inner.no_payload_count, 1);
-        assert_eq!(block_activity_measurement.inner.confirmed_count, 1);
-        assert_eq!(block_activity_measurement.inner.conflicting_count, 1);
-        assert_eq!(block_activity_measurement.inner.no_transaction_count, 3);
+        assert_eq!(block_activity_measurement.transaction_count, 1);
+        assert_eq!(block_activity_measurement.treasury_transaction_count, 1);
+        assert_eq!(block_activity_measurement.milestone_count, 1);
+        assert_eq!(block_activity_measurement.tagged_data_count, 1);
+        assert_eq!(block_activity_measurement.no_payload_count, 1);
+        assert_eq!(block_activity_measurement.confirmed_count, 1);
+        assert_eq!(block_activity_measurement.conflicting_count, 1);
+        assert_eq!(block_activity_measurement.no_transaction_count, 3);
 
-        assert_eq!(milestone_size_measurement.at, ctx.at);
-        assert_eq!(
-            milestone_size_measurement
-                .inner
-                .total_treasury_transaction_payload_bytes,
-            100
-        );
-        assert_eq!(milestone_size_measurement.inner.total_transaction_payload_bytes, 200);
-        assert_eq!(milestone_size_measurement.inner.total_milestone_payload_bytes, 300);
-        assert_eq!(milestone_size_measurement.inner.total_tagged_data_payload_bytes, 400);
-        assert_eq!(milestone_size_measurement.inner.total_milestone_bytes, 1500);
+        assert_eq!(milestone_size_measurement.total_treasury_transaction_payload_bytes, 100);
+        assert_eq!(milestone_size_measurement.total_transaction_payload_bytes, 200);
+        assert_eq!(milestone_size_measurement.total_milestone_payload_bytes, 300);
+        assert_eq!(milestone_size_measurement.total_tagged_data_payload_bytes, 400);
+        assert_eq!(milestone_size_measurement.total_milestone_bytes, 1500);
     }
 }

--- a/src/analytics/tangle/protocol_params.rs
+++ b/src/analytics/tangle/protocol_params.rs
@@ -9,20 +9,15 @@ pub(crate) struct ProtocolParamsMeasurement {
 }
 
 impl Analytics for ProtocolParamsMeasurement {
-    type Measurement = PerMilestone<ProtocolParameters>;
+    type Measurement = ProtocolParameters;
 
     fn begin_milestone(&mut self, _ctx: &dyn AnalyticsContext) {}
 
     fn end_milestone(&mut self, ctx: &dyn AnalyticsContext) -> Option<Self::Measurement> {
         // Ensure that we record it if either the protocol changes or we had no params
-        (!matches!(&self.params, Some(last_params) if last_params == ctx.protocol_params()))
-            .then(|| {
-                self.params.replace(ctx.protocol_params().clone());
-                ctx.protocol_params().clone()
-            })
-            .map(|m| PerMilestone {
-                at: *ctx.at(),
-                inner: m,
-            })
+        (!matches!(&self.params, Some(last_params) if last_params == ctx.protocol_params())).then(|| {
+            self.params.replace(ctx.protocol_params().clone());
+            ctx.protocol_params().clone()
+        })
     }
 }

--- a/src/bin/inx-chronicle/cli/analytics.rs
+++ b/src/bin/inx-chronicle/cli/analytics.rs
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use chronicle::{
-    analytics::{Analytic, DailyAnalytic},
+    analytics::{Analytic, AnalyticsInterval, IntervalAnalytic},
     db::{
-        influxdb::{config::DailyAnalyticsChoice, AnalyticsChoice, InfluxDb},
+        influxdb::{config::IntervalAnalyticsChoice, AnalyticsChoice, InfluxDb},
         MongoDb,
     },
     tangle::{InputSource, Tangle},
     types::tangle::MilestoneIndex,
 };
 use futures::TryStreamExt;
+use tracing::info;
 
 pub async fn fill_analytics<I: 'static + InputSource + Clone>(
     db: &MongoDb,
@@ -23,15 +24,14 @@ pub async fn fill_analytics<I: 'static + InputSource + Clone>(
 ) -> eyre::Result<()> {
     let mut join_set = tokio::task::JoinSet::new();
 
-    let chunk_size = (end_milestone.0 - start_milestone.0) / num_tasks as u32
-        + ((end_milestone.0 - start_milestone.0) % num_tasks as u32 != 0) as u32;
+    let chunk_size = (end_milestone.0 - start_milestone.0) / num_tasks as u32;
 
     let analytics_choices = if analytics.is_empty() {
         super::influxdb::all_analytics()
     } else {
         analytics.iter().copied().collect()
     };
-    tracing::info!("Computing the following analytics: {:?}", analytics_choices);
+    info!("Computing the following analytics: {:?}", analytics_choices);
 
     for i in 0..num_tasks {
         let db = db.clone();
@@ -40,7 +40,16 @@ pub async fn fill_analytics<I: 'static + InputSource + Clone>(
         let analytics_choices = analytics_choices.clone();
 
         join_set.spawn(async move {
-            let start_milestone = start_milestone + i as u32 * chunk_size;
+            let mut start_milestone = start_milestone + i as u32 * chunk_size;
+            // We have to add work for those tasks that get the remainders
+            let remainder = (end_milestone.0 - start_milestone.0) % num_tasks as u32;
+            let chunk_size = if i < remainder as usize {
+                start_milestone += i as u32;
+                chunk_size + 1
+            } else {
+                start_milestone += remainder;
+                chunk_size
+            };
 
             let mut state: Option<AnalyticsState> = None;
 
@@ -95,7 +104,7 @@ pub async fn fill_analytics<I: 'static + InputSource + Clone>(
                         })
                         .await?;
                 }
-                tracing::info!(
+                info!(
                     "Finished analytics for milestone {} in {}ms.",
                     milestone.at.milestone_index,
                     elapsed.as_millis()
@@ -111,25 +120,23 @@ pub async fn fill_analytics<I: 'static + InputSource + Clone>(
     Ok(())
 }
 
-pub async fn fill_daily_analytics(
+pub async fn fill_interval_analytics(
     db: &MongoDb,
     influx_db: &InfluxDb,
     start_date: time::Date,
     end_date: time::Date,
+    interval: AnalyticsInterval,
     num_tasks: usize,
-    analytics: &[DailyAnalyticsChoice],
+    analytics: &[IntervalAnalyticsChoice],
 ) -> eyre::Result<()> {
     let mut join_set = tokio::task::JoinSet::new();
 
-    let chunk_size = (end_date - start_date).whole_days() as usize / num_tasks
-        + ((end_date - start_date).whole_days() as usize % num_tasks != 0) as usize;
-
     let analytics_choices = if analytics.is_empty() {
-        super::influxdb::all_daily_analytics()
+        super::influxdb::all_interval_analytics()
     } else {
         analytics.iter().copied().collect()
     };
-    tracing::info!("Computing the following daily analytics: {:?}", analytics_choices);
+    info!("Computing the following {interval} analytics for {start_date}..{end_date}: {analytics_choices:?}",);
 
     for i in 0..num_tasks {
         let db = db.clone();
@@ -137,18 +144,33 @@ pub async fn fill_daily_analytics(
         let analytics_choices = analytics_choices.clone();
 
         join_set.spawn(async move {
-            let start_date = start_date + time::Duration::days((i * chunk_size) as _);
+            let mut date = start_date;
+            for _ in 0..i {
+                date = interval.end_date(&date);
+                if date >= end_date {
+                    break;
+                }
+            }
 
-            let mut analytics = analytics_choices.iter().map(DailyAnalytic::init).collect::<Vec<_>>();
+            let mut analytics = analytics_choices.iter().map(IntervalAnalytic::init).collect::<Vec<_>>();
 
-            for delta in 0..chunk_size {
+            while date < end_date {
                 let start_time = std::time::Instant::now();
 
-                let date = start_date + time::Duration::days(delta as _);
-                db.update_daily_analytics(&mut analytics, &influx_db, date).await?;
+                db.update_interval_analytics(&mut analytics, &influx_db, date, interval)
+                    .await?;
 
-                let elapsed = start_time.elapsed();
-                tracing::info!("Finished analytics for {} in {}ms.", date, elapsed.as_millis());
+                let elapsed = start_time.elapsed().as_millis();
+                info!(
+                    "Finished {interval} analytics for {date}..{} in {elapsed}ms.",
+                    interval.end_date(&date)
+                );
+                for _ in 0..num_tasks {
+                    date = interval.end_date(&date);
+                    if date >= end_date {
+                        break;
+                    }
+                }
             }
             eyre::Result::<_>::Ok(())
         });

--- a/src/db/collections/outputs/indexer/mod.rs
+++ b/src/db/collections/outputs/indexer/mod.rs
@@ -367,6 +367,32 @@ impl OutputCollection {
         )
         .await?;
 
+        self.create_index(
+            IndexModel::builder()
+                .keys(doc! { "metadata.booked.milestone_timestamp": -1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("output_booked_milestone_timestamp".to_string())
+                        .build(),
+                )
+                .build(),
+            None,
+        )
+        .await?;
+
+        self.create_index(
+            IndexModel::builder()
+                .keys(doc! { "metadata.spent_metadata.spent.milestone_timestamp": -1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("output_spent_milestone_timestamp".to_string())
+                        .build(),
+                )
+                .build(),
+            None,
+        )
+        .await?;
+
         Ok(())
     }
 }

--- a/src/db/collections/outputs/mod.rs
+++ b/src/db/collections/outputs/mod.rs
@@ -497,17 +497,19 @@ impl OutputCollection {
     }
 
     /// Get the address activity in a date
-    pub async fn get_address_activity_count(&self, date: time::Date) -> Result<usize, Error> {
+    pub async fn get_address_activity_count_in_range(
+        &self,
+        start_date: time::Date,
+        end_date: time::Date,
+    ) -> Result<usize, Error> {
         #[derive(Deserialize)]
         struct Res {
             count: usize,
         }
 
-        let date = date.midnight().assume_utc();
-
         let (start_timestamp, end_timestamp) = (
-            MilestoneTimestamp::from(date),
-            MilestoneTimestamp::from(date + time::Duration::days(1)),
+            MilestoneTimestamp::from(start_date.midnight().assume_utc()),
+            MilestoneTimestamp::from(end_date.midnight().assume_utc()),
         );
 
         Ok(self

--- a/src/db/influxdb/config.rs
+++ b/src/db/influxdb/config.rs
@@ -78,7 +78,7 @@ pub enum AnalyticsChoice {
     AddressBalance,
     BaseTokenActivity,
     BlockActivity,
-    DailyActiveAddresses,
+    ActiveAddresses,
     LedgerOutputs,
     LedgerSize,
     MilestoneSize,
@@ -96,7 +96,7 @@ pub fn all_analytics() -> HashSet<AnalyticsChoice> {
         AnalyticsChoice::AddressBalance,
         AnalyticsChoice::BaseTokenActivity,
         AnalyticsChoice::BlockActivity,
-        AnalyticsChoice::DailyActiveAddresses,
+        AnalyticsChoice::ActiveAddresses,
         AnalyticsChoice::LedgerOutputs,
         AnalyticsChoice::LedgerSize,
         AnalyticsChoice::MilestoneSize,
@@ -107,4 +107,17 @@ pub fn all_analytics() -> HashSet<AnalyticsChoice> {
         AnalyticsChoice::UnlockConditions,
     ]
     .into()
+}
+
+#[allow(missing_docs)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, clap::ValueEnum)]
+pub enum DailyAnalyticsChoice {
+    // Please keep the alphabetic order.
+    ActiveAddresses,
+}
+
+/// Returns a list of trait objects for all analytics.
+pub fn all_daily_analytics() -> HashSet<DailyAnalyticsChoice> {
+    // Please keep the alphabetic order.
+    [DailyAnalyticsChoice::ActiveAddresses].into()
 }

--- a/src/db/influxdb/config.rs
+++ b/src/db/influxdb/config.rs
@@ -111,13 +111,13 @@ pub fn all_analytics() -> HashSet<AnalyticsChoice> {
 
 #[allow(missing_docs)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, clap::ValueEnum)]
-pub enum DailyAnalyticsChoice {
+pub enum IntervalAnalyticsChoice {
     // Please keep the alphabetic order.
     ActiveAddresses,
 }
 
 /// Returns a list of trait objects for all analytics.
-pub fn all_daily_analytics() -> HashSet<DailyAnalyticsChoice> {
+pub fn all_interval_analytics() -> HashSet<IntervalAnalyticsChoice> {
     // Please keep the alphabetic order.
-    [DailyAnalyticsChoice::ActiveAddresses].into()
+    [IntervalAnalyticsChoice::ActiveAddresses].into()
 }


### PR DESCRIPTION
This PR adds the `fill-daily-analytics` command to the CLI and removes daily calculations from the regular workflow, including during syncing. This means the only way to gather daily analytics is by calling the CLI command.

This PR adds two additional indexes to support querying for outputs by timestamp.

## Reasoning
There are two main issues with using per-milestone data to calculate daily analytics.
1. The date transitions are not simple. We can only know that we should calculate a date by having two milestones and comparing the dates. This creates situations where it is possible to miss analytics even when syncing. Moreover, the code to support these calculations is over-complex.
2. Filling analytics per-milestone using tasks can miss date transitions, as one task can finish on the last milestone of a day, while another can begin on the next.

This also neatly removes the problem of running `fill-analytics` only for daily analytics (which would not be efficient).

INX data does not support this workflow, as the Unit of Work is a milestone, not a date. Instead, this PR uses MongoDB exclusively to gather these analytics. This is performant enough given that the query must only be run once per day.

## Future Work
It may be that we eventually want to run these analytics during syncing. Comparing milestone timestamps in this case may be "good enough" to support this.