### PR TITLE
fix(inx): remove startup checks and revert influx update that breaks analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "influxdb"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89ca4f249249197d3c3247da793729bda8ec1cee2d143b22cd11ab7f8dc42e2"
+checksum = "39023407f0546c3b30607950f8b600c7db4ef7621fbaa0159de733d73e68b23f"
 dependencies = [
  "chrono",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ uuid = { version = "1.3", default-features = false, features = [ "v4" ] }
 
 # Optional
 chrono = { version = "0.4", default-features = false, features = [ "std" ], optional = true }
-influxdb = { version = "0.6", default-features = false, features = [ "use-serde", "reqwest-client-rustls", "derive" ], optional = true }
+influxdb = { version = "0.5", default-features = false, features = [ "use-serde", "reqwest-client-rustls", "derive" ], optional = true }
 
 # API
 auth-helper = { version = "0.3", default-features = false, optional = true }

--- a/src/bin/inx-chronicle/inx/error.rs
+++ b/src/bin/inx-chronicle/inx/error.rs
@@ -16,8 +16,6 @@ pub enum InxWorkerError {
     #[cfg(feature = "analytics")]
     #[error("missing application state")]
     MissingAppState,
-    #[error("network changed from previous run. old network name: `{old}`, new network name: `{new}`")]
-    NetworkChanged { old: String, new: String },
     #[error("node pruned required milestones between `{start}` and `{end}`")]
     SyncMilestoneGap { start: MilestoneIndex, end: MilestoneIndex },
     #[error("node confirmed milestone index `{node}` is less than index in database `{db}`")]


### PR DESCRIPTION
# Description

This PR removes the unnecessary checks at startup that verify the protocol parameters. This behavior was also causing an issue where a protocol update would break Chronicle if the network name changed and Chronicle was restarted before it reached the milestone with the new params.

## Notes to Reviewer

<!--
The following are examples of particular points that you would like reviewers to pay attention to. Add or remove
items as appropriate for this PR.
-->

As a reviewer, please pay particular attention to the following areas when reviewing this PR and tick the above boxes after you have completed the steps.

#### INX Changes
* [ ] Run chronicle using an INX connection.
