### PR TITLE
fix(api): only perform write ops if a write feature is enabled

### DIFF
--- a/src/bin/inx-chronicle/main.rs
+++ b/src/bin/inx-chronicle/main.rs
@@ -49,6 +49,7 @@ async fn main() -> eyre::Result<()> {
 
     check_migration_version(&db).await?;
 
+    #[cfg(feature = "inx")]
     build_indexes(&db).await?;
 
     let mut tasks: JoinSet<eyre::Result<()>> = JoinSet::new();

--- a/src/bin/inx-chronicle/migrations/mod.rs
+++ b/src/bin/inx-chronicle/migrations/mod.rs
@@ -90,11 +90,13 @@ pub async fn check_migration_version(db: &MongoDb) -> eyre::Result<()> {
                 .await?
                 .is_some()
             {
+                #[cfg(feature = "inx")]
                 migrate(db).await?;
             }
         }
         Some(v) if v == latest_version => (),
         Some(_) => {
+            #[cfg(feature = "inx")]
             migrate(db).await?;
         }
     }

--- a/src/bin/inx-chronicle/migrations/mod.rs
+++ b/src/bin/inx-chronicle/migrations/mod.rs
@@ -92,12 +92,17 @@ pub async fn check_migration_version(db: &MongoDb) -> eyre::Result<()> {
             {
                 #[cfg(feature = "inx")]
                 migrate(db).await?;
+                #[cfg(not(feature = "inx"))]
+                bail!("expected migration {}, found none", latest_version);
             }
         }
-        Some(v) if v == latest_version => (),
-        Some(_) => {
-            #[cfg(feature = "inx")]
-            migrate(db).await?;
+        Some(v) => {
+            if v != latest_version {
+                #[cfg(feature = "inx")]
+                migrate(db).await?;
+                #[cfg(not(feature = "inx"))]
+                bail!("expected migration {}, found {}", latest_version, v);
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
## Linked Issues

<!-- Please provide the issue number corresponding to this PR. -->

* Closes #1196

## Notes to Reviewer

<!--
The following are examples of particular points that you would like reviewers to pay attention to. Add or remove
items as appropriate for this PR.
-->

As a reviewer, please pay particular attention to the following areas when reviewing this PR and tick the above boxes after you have completed the steps.

#### API Changes
* [ ] Run chronicle with only the `api` feature enabled against a read-only mongo instance.
