### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       # - "-c"
       # - "config_testnet.json"
       # - "config_alphanet.json"
+      - "--p2p.autopeering.enabled=true”
       - "--inx.enabled=true"
       - "--inx.bindAddress=hornet:9029"
       - "--prometheus.enabled=true"


### PR DESCRIPTION
I added "--p2p.autopeering.enabled=true” to this line, otherwise, the hornet will not be auto peering and it will not work.

Ways to reproduce:
* Run `docker compose` as-is without modifying it.

(edited by @Alex6323 : I allowed me to change the description to remove the redundant information)