### PR TITLE
feat(influx): retry pushing measurements to InfluxDb

### DIFF
--- a/src/bin/inx-chronicle/cli/influx/mod.rs
+++ b/src/bin/inx-chronicle/cli/influx/mod.rs
@@ -17,6 +17,9 @@ pub struct InfluxDbArgs {
     /// The InfluxDb username.
     #[arg(long, value_name = "USERNAME", env = "INFLUXDB_USERNAME", default_value = influxdb::DEFAULT_USERNAME)]
     pub influxdb_username: String,
+    /// The maximum number of attempts pushing measurements to InfluxDb.
+    #[arg(long, value_name = "NUM", default_value_t = 3)]
+    pub influxdb_max_retries: usize,
     /// The InfluxDb password.
     #[arg(long, value_name = "PASSWORD", env = "INFLUXDB_PASSWORD", default_value = influxdb::DEFAULT_PASSWORD)]
     pub influxdb_password: String,
@@ -34,6 +37,7 @@ impl From<&InfluxDbArgs> for InfluxDbConfig {
             url: value.influxdb_url.clone(),
             username: value.influxdb_username.clone(),
             password: value.influxdb_password.clone(),
+            max_retries: value.influxdb_max_retries,
             #[cfg(feature = "analytics")]
             analytics_enabled: !value.analytics_args.disable_analytics,
             #[cfg(feature = "analytics")]

--- a/src/bin/inx-chronicle/inx/influx/mod.rs
+++ b/src/bin/inx-chronicle/inx/influx/mod.rs
@@ -12,7 +12,7 @@ impl InxWorker {
     pub async fn update_influx<'a>(
         &self,
         milestone: &Milestone<'a, Inx>,
-        #[cfg(feature = "analytics")] analytics_info: Option<&mut analytics::AnalyticsInfo>,
+        #[cfg(feature = "analytics")] analytics_info: &mut Option<&mut analytics::AnalyticsInfo>,
         #[cfg(feature = "metrics")] milestone_start_time: std::time::Instant,
     ) -> eyre::Result<()> {
         #[cfg(all(feature = "analytics", feature = "metrics"))]

--- a/src/db/influxdb/config.rs
+++ b/src/db/influxdb/config.rs
@@ -11,6 +11,8 @@ pub const DEFAULT_URL: &str = "http://localhost:8086";
 pub const DEFAULT_USERNAME: &str = "root";
 /// The default InfluxDb password.
 pub const DEFAULT_PASSWORD: &str = "password";
+/// The default number of attempts to push data to InfluxDb.
+pub const DEFAULT_MAX_RETRIES: usize = 3;
 /// The default whether to enable influx analytics writes.
 #[cfg(feature = "analytics")]
 pub const DEFAULT_ANALYTICS_ENABLED: bool = true;
@@ -34,6 +36,8 @@ pub struct InfluxDbConfig {
     pub username: String,
     /// The InfluxDb password.
     pub password: String,
+    /// The maximum number of attempts pushing measurements to InfluxDb.
+    pub max_retries: usize,
     /// Whether to enable influx analytics writes.
     #[cfg(feature = "analytics")]
     pub analytics_enabled: bool,
@@ -57,6 +61,7 @@ impl Default for InfluxDbConfig {
             url: DEFAULT_URL.to_string(),
             username: DEFAULT_USERNAME.to_string(),
             password: DEFAULT_PASSWORD.to_string(),
+            max_retries: DEFAULT_MAX_RETRIES,
             #[cfg(feature = "analytics")]
             analytics_enabled: DEFAULT_ANALYTICS_ENABLED,
             #[cfg(feature = "analytics")]


### PR DESCRIPTION
## Linked Issues

<!-- Please provide the issue number corresponding to this PR. -->

It's a feature but also should fix this bug as Chronicle will be more resilient to InfluxDb timeouts:

* Closes #1228

## Notes to Reviewer

<!--
The following are examples of particular points that you would like reviewers to pay attention to. Add or remove
items as appropriate for this PR.
-->

As a reviewer, please pay particular attention to the following areas when reviewing this PR and tick the above boxes after you have completed the steps.

#### CLI Changes
* [ ] Test the new `InfluxDb` CLI option `--max-retries`

#### INX Changes
* [ ] Run chronicle using an INX connection (and shutdown the influx container at some point for a bit to confirm that Chronicle's retry mechanism works).
