### PR TITLE
fix: forward worker errors to main exit code

### DIFF
--- a/src/bin/inx-chronicle/main.rs
+++ b/src/bin/inx-chronicle/main.rs
@@ -120,6 +120,7 @@ async fn main() -> eyre::Result<()> {
         res = process::interrupt_or_terminate() => {
             if let Err(err) = res {
                 tracing::error!("subscribing to OS interrupt signals failed with error: {err}; shutting down");
+                exit_code = Err(err);
             } else {
                 tracing::info!("received ctrl-c or terminate; shutting down");
             }
@@ -139,6 +140,7 @@ async fn main() -> eyre::Result<()> {
         res = process::interrupt_or_terminate() => {
             if let Err(err) = res {
                 tracing::error!("subscribing to OS interrupt signals failed with error: {err}; aborting");
+                exit_code = Err(err);
             } else {
                 tracing::info!("received second ctrl-c or terminate; aborting");
             }

--- a/src/bin/inx-chronicle/main.rs
+++ b/src/bin/inx-chronicle/main.rs
@@ -113,6 +113,8 @@ async fn main() -> eyre::Result<()> {
         });
     }
 
+    let mut exit_code = Ok(());
+
     // We wait for either the interrupt signal to arrive or for a component of our system to signal a shutdown.
     tokio::select! {
         res = process::interrupt_or_terminate() => {
@@ -125,6 +127,7 @@ async fn main() -> eyre::Result<()> {
         res = tasks.join_next() => {
             if let Some(Ok(Err(err))) = res {
                 tracing::error!("A worker failed with error: {err}");
+                exit_code = Err(err);
             }
         },
     }
@@ -147,7 +150,7 @@ async fn main() -> eyre::Result<()> {
         },
     }
 
-    Ok(())
+    exit_code
 }
 
 fn set_up_logging() -> eyre::Result<()> {


### PR DESCRIPTION
## Linked Issues

<!-- Please provide the issue number corresponding to this PR. -->

* Closes #1228 

## Notes to Reviewer

<!--
The following are examples of particular points that you would like reviewers to pay attention to. Add or remove
items as appropriate for this PR.
-->

As a reviewer, please pay particular attention to the following areas when reviewing this PR and tick the above boxes after you have completed the steps.

* [x] Run chronicle and cause an error to occur (ex. by stopping the influx server). Ensure that the error is propagated to the exit code of the application.
* [x] Run chronicle as a docker image with a restart policy with retries and do above. Ensure that the docker image restarts.
