### PR TITLE
chore(logging): rephrase logs during shutdown

### DIFF
--- a/src/bin/inx-chronicle/main.rs
+++ b/src/bin/inx-chronicle/main.rs
@@ -127,7 +127,7 @@ async fn main() -> eyre::Result<()> {
         },
         res = tasks.join_next() => {
             if let Some(Ok(Err(err))) = res {
-                tracing::error!("A worker failed with error: {err}");
+                tracing::error!("a worker failed with error: {err}");
                 exit_code = Err(err);
             }
         },
@@ -145,10 +145,10 @@ async fn main() -> eyre::Result<()> {
                 tracing::info!("received second ctrl-c or terminate; aborting");
             }
             tasks.shutdown().await;
-            tracing::info!("Abort successful");
+            tracing::info!("all tasks successfully aborted");
         },
         _ = async { while tasks.join_next().await.is_some() {} } => {
-            tracing::info!("Shutdown successful");
+            tracing::info!("all tasks successfully resolved");
         },
     }
 

--- a/src/bin/inx-chronicle/main.rs
+++ b/src/bin/inx-chronicle/main.rs
@@ -145,10 +145,10 @@ async fn main() -> eyre::Result<()> {
                 tracing::info!("received second ctrl-c or terminate; aborting");
             }
             tasks.shutdown().await;
-            tracing::info!("runtime successfully aborted");
+            tracing::info!("runtime aborted");
         },
         _ = async { while tasks.join_next().await.is_some() {} } => {
-            tracing::info!("runtime successfully stopped");
+            tracing::info!("runtime stopped");
         },
     }
 

--- a/src/bin/inx-chronicle/main.rs
+++ b/src/bin/inx-chronicle/main.rs
@@ -145,10 +145,10 @@ async fn main() -> eyre::Result<()> {
                 tracing::info!("received second ctrl-c or terminate; aborting");
             }
             tasks.shutdown().await;
-            tracing::info!("all tasks successfully aborted");
+            tracing::info!("runtime successfully aborted");
         },
         _ = async { while tasks.join_next().await.is_some() {} } => {
-            tracing::info!("all tasks successfully resolved");
+            tracing::info!("runtime successfully stopped");
         },
     }
 


### PR DESCRIPTION
I think "Shutdown successful" was confusing to people. We can circumvent this by being more accurate in logging that all our tasks have successfully resolved due to the shutdown/abort signal.