### PR TITLE
Fix the hornet config specification

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       # - "-c"
       # - "config_testnet.json"
       # - "config_alphanet.json"
-      - "-c ${HORNET_CONFIG_PATH}"
+      - "--config=${HORNET_CONFIG_PATH}"
       - "--inx.enabled=true"
       - "--inx.bindAddress=hornet:9029"
       - "--prometheus.enabled=true"


### PR DESCRIPTION
The current config as below does not work as of hornet config file not found error
`- "-c ${HORNET_CONFIG_PATH}"`

but this works well:
`- "--config=${HORNET_CONFIG_PATH}"`