### PR TITLE
feat(analytics): consider expiring and locked outputs

### DIFF
--- a/src/analytics/ledger/active_addresses.rs
+++ b/src/analytics/ledger/active_addresses.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
@@ -43,7 +43,7 @@ impl IntervalAnalytics for AddressActivityMeasurement {
 impl Analytics for AddressActivityAnalytics {
     type Measurement = AddressActivityMeasurement;
 
-    fn handle_transaction(&mut self, consumed: &[LedgerSpent], created: &[LedgerOutput], ctx: &dyn AnalyticsContext) {
+    fn handle_transaction(&mut self, consumed: &[LedgerSpent], created: &[LedgerOutput], _ctx: &dyn AnalyticsContext) {
         for output in consumed {
             if let Some(a) = output.owning_address() {
                 self.addresses.insert(*a);
@@ -51,7 +51,7 @@ impl Analytics for AddressActivityAnalytics {
         }
 
         for output in created {
-            if let Some(a) = output.output.owning_address(ctx.at().milestone_timestamp) {
+            if let Some(a) = output.owning_address() {
                 self.addresses.insert(*a);
             }
         }

--- a/src/bin/inx-chronicle/cli/analytics.rs
+++ b/src/bin/inx-chronicle/cli/analytics.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
@@ -23,7 +23,9 @@ use tracing::{debug, info};
 
 use crate::config::ChronicleConfig;
 
-/// This command accepts both milestone index and date ranges. The following rules apply:
+/// This command accepts both milestone index and date ranges.
+///
+/// The following rules apply:
 ///
 /// - If both milestone and date are specified, the date will be used for interval analytics
 /// while the milestone will be used for per-milestone analytics.

--- a/src/model/block/payload/transaction/mod.rs
+++ b/src/model/block/payload/transaction/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Module containing types related to transactions.
@@ -17,7 +17,7 @@ pub mod output;
 pub mod unlock;
 
 /// Uniquely identifies a transaction.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash, PartialOrd, Ord)]
 #[serde(transparent)]
 pub struct TransactionId(#[serde(with = "bytify")] pub [u8; Self::LENGTH]);
 

--- a/src/model/block/payload/transaction/output/unlock_condition/timelock.rs
+++ b/src/model/block/payload/transaction/output/unlock_condition/timelock.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
@@ -13,7 +13,7 @@ use crate::model::tangle::MilestoneTimestamp;
 /// Defines a unix timestamp until which the output can not be unlocked.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimelockUnlockCondition {
-    timestamp: MilestoneTimestamp,
+    pub(crate) timestamp: MilestoneTimestamp,
 }
 
 impl<T: Borrow<iota::TimelockUnlockCondition>> From<T> for TimelockUnlockCondition {


### PR DESCRIPTION
## Description

This PR tracks expiring and locked outputs in the address balance analytics, so that when the milestone is eventually handled those amounts will properly be transferred or added to the appropriate address. Each output with an expiration or timelock will create a record in the maps. 

**However!!** this has potentially serious performance implications, primarily due to the memory usage of these tracking structures, which **have no bounds!**. 

## Alternatives

Conceptually, the same process could be instead applied to the database using a tracking table, something like this:

```rust
#[derive(Serialize, Deserialize)]
struct Id {
  milestone_timestamp: MilestoneTimestamp,
  output_id: OutputId,
}

#[derive(Serialize, Deserialize)]
struct TrackingDocument {
  _id: Id,
  address: Address,
  expiration_return_address: Option<Address>,
  amount: TokenAmount,
}
```

The usage of this table would be much the same as the `HashMap`s in this PR, and we could instead pass in the records for the current milestone for each balance analytic call. Additionally, this would allow chronicle to update the owning address for records in `OutputCollection` and `LedgerUpdateCollection` per milestone, potentially dramatically improving the functionality and performance of the explorer endpoints.

## Conclusion

Due to the performance concerns, I don't want to merge this PR as-is, but rather keep it as a proof-of-concept for now.