### PR TITLE
fix: race condition for finalized blocks

### DIFF
--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -314,7 +314,7 @@ impl<'a, I: InputSource> Slot<'a, I> {
             db,
         };
 
-        let mut block_stream = self.accepted_block_stream().await?.boxed();
+        let mut block_stream = self.finalized_block_stream().await?.boxed();
 
         while let Some(data) = block_stream.try_next().await? {
             if let Some((payload, metadata)) = data

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -316,6 +316,8 @@ impl<'a, I: InputSource> Slot<'a, I> {
 
         let mut block_stream = self.finalized_block_stream().await?.boxed();
 
+        let mut counter = 0;
+
         while let Some(data) = block_stream.try_next().await? {
             if let Some((payload, metadata)) = data
                 .block
@@ -332,7 +334,10 @@ impl<'a, I: InputSource> Slot<'a, I> {
                 }
             }
             self.handle_block(analytics, &data.block, &ctx).await?;
+            counter += 1;
         }
+
+        println!("analytics blocks: {counter}");
 
         influxdb
             .insert_measurement((analytics as &mut dyn DynAnalytics).take_measurement(&ctx).await?)

--- a/src/bin/inx-chronicle/inx/mod.rs
+++ b/src/bin/inx-chronicle/inx/mod.rs
@@ -109,9 +109,9 @@ impl InxWorker {
         };
 
         debug!(
-            "The node has a pruning epoch index of `{}` and a latest confirmed slot index of `{}`.",
+            "The node has a pruning epoch index of `{}` and a latest finalized slot index of `{}`.",
             node_status.pruning_epoch,
-            node_status.latest_commitment.commitment_id.slot_index()
+            node_status.latest_finalized_commitment.commitment_id.slot_index()
         );
 
         let mut node_configuration = inx.get_node_configuration().await?;
@@ -303,7 +303,7 @@ impl InxWorker {
         tracing::Span::current().record("created", slot.ledger_updates().created_outputs().len());
         tracing::Span::current().record("consumed", slot.ledger_updates().consumed_outputs().len());
 
-        self.handle_accepted_blocks(&slot).await?;
+        self.handle_finalized_blocks(&slot).await?;
 
         #[cfg(feature = "influx")]
         self.update_influx(
@@ -326,7 +326,16 @@ impl InxWorker {
     }
 
     #[instrument(skip_all, err, level = "trace")]
-    async fn handle_accepted_blocks<'a>(&mut self, slot: &Slot<'a, Inx>) -> Result<()> {
+    async fn handle_finalized_blocks<'a>(&mut self, slot: &Slot<'a, Inx>) -> Result<()> {
+        // let mut block_stream = slot.finalized_block_stream().await?.boxed();
+
+        // let mut counter = 0;
+        // while let Some(data) = block_stream.try_next().await? {
+        //     counter += 1;
+        // }
+
+        // println!("inx blocks: {counter}");
+
         let blocks_stream = slot.finalized_block_stream().await?;
 
         let mut tasks = blocks_stream

--- a/src/bin/inx-chronicle/inx/mod.rs
+++ b/src/bin/inx-chronicle/inx/mod.rs
@@ -327,7 +327,7 @@ impl InxWorker {
 
     #[instrument(skip_all, err, level = "trace")]
     async fn handle_accepted_blocks<'a>(&mut self, slot: &Slot<'a, Inx>) -> Result<()> {
-        let blocks_stream = slot.accepted_block_stream().await?;
+        let blocks_stream = slot.finalized_block_stream().await?;
 
         let mut tasks = blocks_stream
             .try_chunks(INSERT_BATCH_SIZE)

--- a/src/tangle/slot_stream.rs
+++ b/src/tangle/slot_stream.rs
@@ -25,7 +25,7 @@ pub struct Slot<'a, I: InputSource> {
 }
 
 impl<'a, I: InputSource> Slot<'a, I> {
-    /// Get the slot index.
+    /// Get the slot's index.
     pub fn index(&self) -> SlotIndex {
         self.commitment.commitment_id.slot_index()
     }
@@ -53,12 +53,14 @@ impl<'a, I: InputSource> Slot<'a, I> {
         &self,
     ) -> Result<impl Stream<Item = Result<BlockWithTransactionMetadata, I::Error>> + '_, I::Error> {
         while !self.is_finalized().await {
+            println!("not finalized: {}", self.index());
             tokio::time::sleep(core::time::Duration::from_millis(100)).await;
         }
+        println!("finalized: {}", self.index());
 
         Ok(self
             .source
-            .finalized_blocks(self.index())
+            .accepted_blocks(self.index())
             .await?
             .try_filter(|block_with_metadata| {
                 futures::future::ready(block_with_metadata.metadata.block_state == Some(BlockState::Finalized))

--- a/src/tangle/slot_stream.rs
+++ b/src/tangle/slot_stream.rs
@@ -51,7 +51,10 @@ impl<'a, I: InputSource> Slot<'a, I> {
             .accepted_blocks(self.index())
             .await?
             .try_filter(|block_with_metadata| {
-                futures::future::ready(block_with_metadata.metadata.block_state == Some(BlockState::Finalized))
+                futures::future::ready(
+                    block_with_metadata.metadata.block_state == Some(BlockState::Confirmed)
+                        || block_with_metadata.metadata.block_state == Some(BlockState::Finalized),
+                )
             })
             .and_then(|res| async {
                 let transaction = if let Some(transaction_id) = res

--- a/src/tangle/sources/inx.rs
+++ b/src/tangle/sources/inx.rs
@@ -44,7 +44,7 @@ impl InputSource for Inx {
         ))
     }
 
-    async fn finalized_blocks(
+    async fn accepted_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error> {

--- a/src/tangle/sources/inx.rs
+++ b/src/tangle/sources/inx.rs
@@ -44,7 +44,7 @@ impl InputSource for Inx {
         ))
     }
 
-    async fn accepted_blocks(
+    async fn finalized_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error> {
@@ -89,5 +89,15 @@ impl InputSource for Inx {
             .await?;
 
         Ok(LedgerUpdateStore::init(consumed, created))
+    }
+
+    async fn latest_finalized_slot_index(&self) -> Result<SlotIndex, Self::Error> {
+        let mut inx = self.clone();
+        Ok(inx
+            .get_node_status()
+            .await?
+            .latest_finalized_commitment
+            .commitment_id
+            .slot_index())
     }
 }

--- a/src/tangle/sources/memory.rs
+++ b/src/tangle/sources/memory.rs
@@ -46,7 +46,7 @@ impl InputSource for BTreeMap<SlotIndex, InMemoryData> {
         )))
     }
 
-    async fn accepted_blocks(
+    async fn finalized_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error> {
@@ -73,5 +73,9 @@ impl InputSource for BTreeMap<SlotIndex, InMemoryData> {
             .ok_or(InMemoryInputSourceError::MissingBlockData(index))?
             .ledger_updates
             .clone())
+    }
+
+    async fn latest_finalized_slot_index(&self) -> Result<SlotIndex, Self::Error> {
+        todo!()
     }
 }

--- a/src/tangle/sources/memory.rs
+++ b/src/tangle/sources/memory.rs
@@ -46,7 +46,7 @@ impl InputSource for BTreeMap<SlotIndex, InMemoryData> {
         )))
     }
 
-    async fn finalized_blocks(
+    async fn accepted_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error> {

--- a/src/tangle/sources/mod.rs
+++ b/src/tangle/sources/mod.rs
@@ -30,8 +30,8 @@ pub trait InputSource: Send + Sync {
         range: impl RangeBounds<SlotIndex> + Send,
     ) -> Result<BoxStream<Result<Commitment, Self::Error>>, Self::Error>;
 
-    /// A stream of accepted blocks for a given slot index.
-    async fn accepted_blocks(
+    /// A stream of finalized blocks for a given slot index.
+    async fn finalized_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error>;
@@ -41,4 +41,7 @@ pub trait InputSource: Send + Sync {
 
     /// Retrieves the updates to the ledger for a given range of slots.
     async fn ledger_updates(&self, index: SlotIndex) -> Result<LedgerUpdateStore, Self::Error>;
+
+    /// Retrieves the latest finalized slot index.
+    async fn latest_finalized_slot_index(&self) -> Result<SlotIndex, Self::Error>;
 }

--- a/src/tangle/sources/mod.rs
+++ b/src/tangle/sources/mod.rs
@@ -30,8 +30,8 @@ pub trait InputSource: Send + Sync {
         range: impl RangeBounds<SlotIndex> + Send,
     ) -> Result<BoxStream<Result<Commitment, Self::Error>>, Self::Error>;
 
-    /// A stream of finalized blocks for a given slot index.
-    async fn finalized_blocks(
+    /// A stream of (at least) accepted blocks for a given slot index.
+    async fn accepted_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error>;

--- a/src/tangle/sources/mongodb.rs
+++ b/src/tangle/sources/mongodb.rs
@@ -68,7 +68,7 @@ impl InputSource for MongoDb {
         )))
     }
 
-    async fn accepted_blocks(
+    async fn finalized_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error> {
@@ -103,5 +103,9 @@ impl InputSource for MongoDb {
             .await?;
 
         Ok(LedgerUpdateStore::init(consumed, created))
+    }
+
+    async fn latest_finalized_slot_index(&self) -> Result<SlotIndex, Self::Error> {
+        todo!()
     }
 }

--- a/src/tangle/sources/mongodb.rs
+++ b/src/tangle/sources/mongodb.rs
@@ -68,7 +68,7 @@ impl InputSource for MongoDb {
         )))
     }
 
-    async fn finalized_blocks(
+    async fn accepted_blocks(
         &self,
         index: SlotIndex,
     ) -> Result<BoxStream<Result<BlockWithMetadata, Self::Error>>, Self::Error> {


### PR DESCRIPTION
The problem is that we currently call `get_accepted_blocks` too early when blocks were "just" confirmed in the node software. I confirmed this by waiting for 2s before making that call, and then Chronicle was able to fetch them as finalized.

Instead of an arbitrary waiting time, this PR relaxes the block-state requirement for Chronicle to "confirmed or finalized".
